### PR TITLE
Explicitly disable SSLv3 protocol on Net::HTTP connections

### DIFF
--- a/lib/mercadopago.rb
+++ b/lib/mercadopago.rb
@@ -10,6 +10,7 @@ require 'uri'
 require 'net/https'
 require 'yaml'
 require 'version'
+require 'ssl_options_patch'
 
 class MercadoPago
 	def initialize(*args)
@@ -297,6 +298,7 @@ class MercadoPago
 
 			if API_BASE_URL.scheme == "https" # enable SSL/TLS
 				@http.use_ssl = true
+				@http.ssl_options = OpenSSL::SSL::OP_NO_SSLv3
 			end
 
 			@http.set_debug_output debug_logger if debug_logger

--- a/lib/ssl_options_patch.rb
+++ b/lib/ssl_options_patch.rb
@@ -1,0 +1,15 @@
+# This is a workaround for issue #9450 in Ruby core
+# https://bugs.ruby-lang.org/issues/9450
+#
+# Add an :ssl_options accessor to Net::HTTP, which controls the options
+# attribute on the resulting SSLContext. This allows the user to customize
+# behavior of SSL connections, like disabling specific protocol versions.
+
+require 'net/http'
+
+(Net::HTTP::SSL_IVNAMES << :@ssl_options).uniq!
+(Net::HTTP::SSL_ATTRIBUTES << :options).uniq!
+
+Net::HTTP.class_eval do
+  attr_accessor :ssl_options
+end


### PR DESCRIPTION
To disable SSL3, you need to explicitly tell OpenSSL not to use it, so this adds that hint.

Because of bug #9450 in Ruby core, there is no way right now to set these options from Ruby, so this PR also adds an accessor in Net::HTTP for setting them, as a workaround.

https://bugs.ruby-lang.org/issues/9450