### PR TITLE
TLS Version Migration

### DIFF
--- a/lib/mercadopago.rb
+++ b/lib/mercadopago.rb
@@ -300,7 +300,7 @@ class MercadoPago
 				@http.use_ssl = true
 				@http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 				@http.ssl_options = OpenSSL::SSL::OP_NO_SSLv3 # explicitly tell OpenSSL not to use SSL3
-        @http.ssl_version = :TLSv1_2
+				@http.ssl_version = :TLSv1_2
 			end
 
 			@http.set_debug_output debug_logger if debug_logger

--- a/lib/mercadopago.rb
+++ b/lib/mercadopago.rb
@@ -300,6 +300,7 @@ class MercadoPago
 				@http.use_ssl = true
 				@http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 				@http.ssl_options = OpenSSL::SSL::OP_NO_SSLv3 # explicitly tell OpenSSL not to use SSL3
+        @http.ssl_version = :TLSv1_2
 			end
 
 			@http.set_debug_output debug_logger if debug_logger


### PR DESCRIPTION
As it is described [here](http://beta.mercadopago.com.ar/developers/es/guides/pci-compliant-merchants/disabling-tls-10
) MercadoPago will turn off TLS Version 1.0

This force http client to use TLSv1.2, as now the only option to do this would be to monkey patch the ```RestClient``` class.
