### PR TITLE
fix: Avoid using URI.escape when possible

### DIFF
--- a/lib/mercadopago.rb
+++ b/lib/mercadopago.rb
@@ -200,7 +200,10 @@ class MercadoPago
 	end
 
 	def build_query(params)
-		URI.escape(params.collect { |k, v| "#{k}=#{v}" }.join('&'))
+		unless URI.respond_to? :encode_www_form
+			return URI.escape(params.collect { |k, v| "#{k}=#{v}" }.join('&'))
+		end
+		URI.encode_www_form(params)
 	end
 
 	private


### PR DESCRIPTION
Fixes `URI.escape` obsolete warning on ruby >= 2.7.

Example warning:
`<...>/versions/2.7.2/lib/ruby/gems/2.7.0/gems/mercadopago-sdk-1.2.0/lib/mercadopago.rb:303: warning: URI.escape is obsolete`

Reference: https://docs.knapsackpro.com/2020/uri-escape-is-obsolete-percent-encoding-your-query-string