### PR TITLE
Fix broken badge and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ payment = result[:response]
 ## 📚 Documentation 
 
 Visit our Dev Site for further information regarding:
- - [Developer Docs](https://www.mercadopago.com.br/developers/en/docs)
- - [Checkout Bricks](https://www.mercadopago.com.br/developers/en/docs/checkout-bricks/landing)
+ - [Developer Docs](https://www.mercadopago.com/developers/en/docs)
+ - [Checkout Bricks](https://www.mercadopago.com/developers/en/docs/checkout-bricks/landing)
  - [Checkout Pro](https://www.mercadopago.com/developers/en/guides/online-payments/checkout-pro/introduction)
  - [Checkout API](https://www.mercadopago.com/developers/en/guides/online-payments/checkout-api/introduction)
 


### PR DESCRIPTION
The license badge was misconfigured, I've replaced it with a newer format from the same provider.
Old: [![APM](https://img.shields.io/apm/l/vim-mode)](https://github.com/mercadopago/sdk-ruby)
New: ![GitHub](https://img.shields.io/github/license/mercadopago/sdk-ruby)

The link to the credentials page (/panel/credentials)was broken, I've replaced it with a link to the applications list in /panel/app.

In the further information links list
- Swapped "APIs" with the newer, more complete developer docs page.
- Added link to Checkout Bricks
- Removed deprecated Web Tokenize Checkout link.