### PR TITLE
Fix payment create call on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ payment_data = {
     email: 'test_user_123456@testuser.com'
   }
 }
-result = sdk.payment.create(payment_data, custom_request_options)
+result = sdk.payment.create(payment_data, request_options: custom_request_options)
 payment = result[:response]
 
 puts payment


### PR DESCRIPTION
We had previously a call with two parameters that raises an error when we try to execute the code. I just updated to pass the second parameter as keyword parameter.