### PR TITLE
Add WebhookSignatureValidator utility

### DIFF
--- a/lib/mercadopago/webhook/validator.rb
+++ b/lib/mercadopago/webhook/validator.rb
@@ -1,0 +1,237 @@
+# typed: true
+# frozen_string_literal: true
+
+require 'openssl'
+
+module Mercadopago
+  # Webhook signature validation utilities.
+  #
+  # Verifies the authenticity of incoming MercadoPago webhook notifications by
+  # recomputing the HMAC-SHA256 signature locally and comparing it against the
+  # value carried in the +x-signature+ header.
+  #
+  # The validator is stateless, performs no outbound HTTP calls, and does not
+  # depend on any SDK configuration object; the integrator passes the secret
+  # signature explicitly on every call.
+  #
+  # @example Basic usage
+  #   begin
+  #     Mercadopago::Webhook::Validator.validate(
+  #       request.headers['x-signature'],
+  #       request.headers['x-request-id'],
+  #       request.params['data.id'],
+  #       webhook_secret,
+  #       tolerance_seconds: 300
+  #     )
+  #     head :ok
+  #   rescue Mercadopago::Webhook::InvalidWebhookSignatureError
+  #     head :unauthorized
+  #   end
+  module Webhook
+    # Reasons why {Validator.validate} may reject a notification. Each constant
+    # is a +Symbol+; log it alongside the +x-request-id+ for correlation against
+    # the MercadoPago notifications dashboard.
+    module SignatureFailureReason
+      MISSING_SIGNATURE_HEADER   = :missing_signature_header
+      MALFORMED_SIGNATURE_HEADER = :malformed_signature_header
+      MISSING_TIMESTAMP          = :missing_timestamp
+      MISSING_HASH               = :missing_hash
+      SIGNATURE_MISMATCH         = :signature_mismatch
+      TIMESTAMP_OUT_OF_TOLERANCE = :timestamp_out_of_tolerance
+    end
+
+    # Error raised by {Validator.validate} when a webhook signature cannot be confirmed
+    # as originating from MercadoPago. Carries enough context for structured logging
+    # without exposing internal details in the HTTP response body.
+    class InvalidWebhookSignatureError < StandardError
+      # @return [Symbol] one of the {SignatureFailureReason} constants
+      attr_reader :reason
+      # @return [String, nil] x-request-id header value, when available
+      attr_reader :request_id
+      # @return [String, nil] +ts+ value extracted from the signature header
+      attr_reader :timestamp
+
+      # @param reason [Symbol] one of the {SignatureFailureReason} constants
+      # @param request_id [String, nil] x-request-id value associated with the request
+      # @param timestamp [String, nil] +ts+ extracted from the header
+      def initialize(reason, request_id: nil, timestamp: nil)
+        super("Invalid webhook signature: #{reason}")
+        @reason = reason
+        @request_id = request_id
+        @timestamp = timestamp
+      end
+    end
+
+    # Stateless utility that validates the signature of a MercadoPago webhook.
+    #
+    # On failure {validate} raises {InvalidWebhookSignatureError}; on success it
+    # returns +nil+. The comparison is performed in constant time via
+    # +OpenSSL.fixed_length_secure_compare+ to mitigate timing attacks.
+    #
+    # **QR Code notifications are not signed** by MercadoPago — do not call this
+    # validator for those events; they will always fail signature verification.
+    class Validator
+      DEFAULT_SUPPORTED_VERSIONS = %w[v1].freeze
+      private_constant :DEFAULT_SUPPORTED_VERSIONS
+
+      VERSION_KEY_REGEX = /\Av\d+\z/
+      private_constant :VERSION_KEY_REGEX
+
+      # Validates the signature of a MercadoPago webhook notification.
+      #
+      # @param x_signature [String, nil] raw value of the +x-signature+ request header
+      # @param x_request_id [String, nil] value of the +x-request-id+ request header.
+      #   May be +nil+ or blank; in that case the +request-id:+ pair is omitted from
+      #   the manifest before computing the HMAC
+      # @param data_id [String, nil] value of the +data.id+ query parameter. May be +nil+
+      #   or blank; in that case the +id:+ pair is omitted. Lowercased before HMAC
+      # @param secret [String] secret signature configured in Tus Integraciones (HMAC key)
+      # @param tolerance_seconds [Integer, nil] optional maximum allowed drift in seconds
+      #   between the header timestamp and the current clock. Omit to skip the check
+      # @param supported_versions [Array<String>, nil] optional ordered list of signature
+      #   versions to accept. Defaults to +%w[v1]+. The first version found in the
+      #   header is used
+      # @param now [Proc, nil] optional callable returning the current time in
+      #   milliseconds since Unix epoch. Intended for tests
+      # @return [void]
+      # @raise [InvalidWebhookSignatureError] when the signature is missing, malformed,
+      #   or does not match the expected HMAC
+      # @raise [ArgumentError] when +secret+ is +nil+ or empty
+      def self.validate(x_signature, x_request_id, data_id, secret,
+                        tolerance_seconds: nil, supported_versions: nil, now: nil)
+        raise ArgumentError, 'secret must not be empty' if secret.nil? || secret.empty?
+
+        x_signature = normalize(x_signature)
+        x_request_id = normalize(x_request_id)
+        data_id = normalize(data_id)
+        versions = supported_versions && !supported_versions.empty? ? supported_versions : DEFAULT_SUPPORTED_VERSIONS
+        now_proc = now || -> { (Time.now.to_f * 1000).to_i }
+
+        if x_signature.nil?
+          raise InvalidWebhookSignatureError.new(
+            SignatureFailureReason::MISSING_SIGNATURE_HEADER,
+            request_id: x_request_id
+          )
+        end
+
+        ts, hashes = parse_signature_header(x_signature)
+
+        if ts.nil? && hashes.empty?
+          raise InvalidWebhookSignatureError.new(
+            SignatureFailureReason::MALFORMED_SIGNATURE_HEADER,
+            request_id: x_request_id
+          )
+        end
+
+        if ts.nil?
+          raise InvalidWebhookSignatureError.new(
+            SignatureFailureReason::MISSING_TIMESTAMP,
+            request_id: x_request_id
+          )
+        end
+
+        unless ts.match?(/\A\d+\z/)
+          raise InvalidWebhookSignatureError.new(
+            SignatureFailureReason::MALFORMED_SIGNATURE_HEADER,
+            request_id: x_request_id,
+            timestamp: ts
+          )
+        end
+
+        received_hash = nil
+        versions.each do |v|
+          if hashes.key?(v)
+            received_hash = hashes[v]
+            break
+          end
+        end
+
+        if received_hash.nil?
+          raise InvalidWebhookSignatureError.new(
+            SignatureFailureReason::MISSING_HASH,
+            request_id: x_request_id,
+            timestamp: ts
+          )
+        end
+
+        manifest = build_manifest(data_id, x_request_id, ts)
+        computed = OpenSSL::HMAC.hexdigest('SHA256', secret, manifest)
+
+        unless constant_time_equal(computed, received_hash)
+          raise InvalidWebhookSignatureError.new(
+            SignatureFailureReason::SIGNATURE_MISMATCH,
+            request_id: x_request_id,
+            timestamp: ts
+          )
+        end
+
+        unless tolerance_seconds.nil?
+          drift_ms = (now_proc.call - ts.to_i).abs
+          if drift_ms > tolerance_seconds * 1000
+            raise InvalidWebhookSignatureError.new(
+              SignatureFailureReason::TIMESTAMP_OUT_OF_TOLERANCE,
+              request_id: x_request_id,
+              timestamp: ts
+            )
+          end
+        end
+
+        nil
+      end
+
+      # Returns the trimmed value or +nil+ for missing/whitespace inputs.
+      def self.normalize(value)
+        return nil if value.nil?
+
+        text = value.to_s.strip
+        text.empty? ? nil : text
+      end
+      private_class_method :normalize
+
+      # Parses the +x-signature+ header into +[ts, {vN => hash}]+.
+      def self.parse_signature_header(header)
+        hashes = {}
+        ts = nil
+        header.split(',').each do |part|
+          key, value = part.split('=', 2)
+          next if key.nil? || value.nil?
+
+          key = key.strip.downcase
+          value = value.strip
+          next if key.empty? || value.empty?
+
+          if key == 'ts'
+            ts = value
+          elsif key.match?(VERSION_KEY_REGEX)
+            hashes[key] = value
+          end
+        end
+        [ts, hashes]
+      end
+      private_class_method :parse_signature_header
+
+      # Constant-time string comparison. Returns +false+ for unequal-length
+      # inputs without leaking the length difference via timing.
+      def self.constant_time_equal(left, right)
+        return false if left.bytesize != right.bytesize
+
+        diff = 0
+        left_bytes = left.bytes
+        right_bytes = right.bytes
+        left_bytes.each_with_index { |b, i| diff |= b ^ right_bytes[i] }
+        diff.zero?
+      end
+      private_class_method :constant_time_equal
+
+      # Builds the HMAC manifest, omitting empty pairs per the documented rule.
+      def self.build_manifest(data_id, request_id, ts)
+        parts = []
+        parts << "id:#{data_id.downcase}" unless data_id.nil?
+        parts << "request-id:#{request_id}" unless request_id.nil?
+        parts << "ts:#{ts}"
+        "#{parts.join(';')};"
+      end
+      private_class_method :build_manifest
+    end
+  end
+end

--- a/tests/test_webhook_signature_validator.rb
+++ b/tests/test_webhook_signature_validator.rb
@@ -1,0 +1,152 @@
+# typed: true
+# frozen_string_literal: true
+
+require_relative '../lib/mercadopago/webhook/validator'
+require 'openssl'
+require 'minitest/autorun'
+
+# Unit tests for {Mercadopago::Webhook::Validator}. Self-contained; no network.
+class TestWebhookSignatureValidator < Minitest::Test
+  SECRET = 'your_secret_key_here'
+  REQUEST_ID = '2066ca19-c6f1-498a-be75-1923005edd06'
+  DATA_ID_RAW = 'ORD01JQ4S4KY8HWQ6NA5PXB65B3D3'
+  DATA_ID_LOWER = 'ord01jq4s4ky8hwq6na5pxb65b3d3'
+  TS = '1742505638683'
+
+  Validator = Mercadopago::Webhook::Validator
+  Error = Mercadopago::Webhook::InvalidWebhookSignatureError
+  Reason = Mercadopago::Webhook::SignatureFailureReason
+
+  def compute_hash(data_id, request_id, ts, secret)
+    parts = []
+    parts << "id:#{data_id.downcase}" if data_id && !data_id.empty?
+    parts << "request-id:#{request_id}" if request_id && !request_id.empty?
+    parts << "ts:#{ts}"
+    manifest = "#{parts.join(';')};"
+    OpenSSL::HMAC.hexdigest('SHA256', secret, manifest)
+  end
+
+  def build_header(hash, ts = TS, version = 'v1')
+    "ts=#{ts},#{version}=#{hash}"
+  end
+
+  def valid_hash
+    compute_hash(DATA_ID_LOWER, REQUEST_ID, TS, SECRET)
+  end
+
+  # case 1
+  def test_happy_path_lowercase
+    Validator.validate(build_header(valid_hash), REQUEST_ID, DATA_ID_LOWER, SECRET)
+  end
+
+  # case 2
+  def test_uppercase_dataid_is_lowercased
+    Validator.validate(build_header(valid_hash), REQUEST_ID, DATA_ID_RAW, SECRET)
+  end
+
+  # case 3
+  def test_malformed_header_raises_malformed
+    err = assert_raises(Error) do
+      Validator.validate('this-is-garbage', REQUEST_ID, DATA_ID_LOWER, SECRET)
+    end
+    assert_equal Reason::MALFORMED_SIGNATURE_HEADER, err.reason
+    assert_equal REQUEST_ID, err.request_id
+  end
+
+  # case 4
+  def test_missing_header_raises_missing_header
+    err = assert_raises(Error) do
+      Validator.validate(nil, REQUEST_ID, DATA_ID_LOWER, SECRET)
+    end
+    assert_equal Reason::MISSING_SIGNATURE_HEADER, err.reason
+  end
+
+  # case 5
+  def test_missing_ts_raises_missing_timestamp
+    err = assert_raises(Error) do
+      Validator.validate("v1=#{valid_hash}", REQUEST_ID, DATA_ID_LOWER, SECRET)
+    end
+    assert_equal Reason::MISSING_TIMESTAMP, err.reason
+  end
+
+  # case 6
+  def test_missing_v1_raises_missing_hash
+    err = assert_raises(Error) do
+      Validator.validate("ts=#{TS}", REQUEST_ID, DATA_ID_LOWER, SECRET)
+    end
+    assert_equal Reason::MISSING_HASH, err.reason
+    assert_equal TS, err.timestamp
+  end
+
+  # case 7
+  def test_tampered_hash_raises_signature_mismatch
+    h = valid_hash
+    tampered = h[0..-3] + (h.end_with?('00') ? 'ff' : '00')
+    err = assert_raises(Error) do
+      Validator.validate(build_header(tampered), REQUEST_ID, DATA_ID_LOWER, SECRET)
+    end
+    assert_equal Reason::SIGNATURE_MISMATCH, err.reason
+  end
+
+  # case 8
+  def test_outside_tolerance_raises
+    stale_ts = ((Time.now.to_f * 1000).to_i - 30 * 60 * 1000).to_s
+    h = compute_hash(DATA_ID_LOWER, REQUEST_ID, stale_ts, SECRET)
+    err = assert_raises(Error) do
+      Validator.validate(build_header(h, stale_ts), REQUEST_ID, DATA_ID_LOWER, SECRET,
+                         tolerance_seconds: 300)
+    end
+    assert_equal Reason::TIMESTAMP_OUT_OF_TOLERANCE, err.reason
+  end
+
+  def test_within_tolerance_passes
+    current = (Time.now.to_f * 1000).to_i.to_s
+    h = compute_hash(DATA_ID_LOWER, REQUEST_ID, current, SECRET)
+    Validator.validate(build_header(h, current), REQUEST_ID, DATA_ID_LOWER, SECRET,
+                       tolerance_seconds: 300)
+  end
+
+  # case 9
+  def test_dataid_absent_excludes_id_pair
+    h = compute_hash(nil, REQUEST_ID, TS, SECRET)
+    Validator.validate(build_header(h), REQUEST_ID, nil, SECRET)
+  end
+
+  # case 10
+  def test_request_id_absent_excludes_request_id_pair
+    h = compute_hash(DATA_ID_LOWER, nil, TS, SECRET)
+    Validator.validate(build_header(h), nil, DATA_ID_LOWER, SECRET)
+  end
+
+  # case 11
+  def test_both_absent_yields_ts_only
+    h = compute_hash(nil, nil, TS, SECRET)
+    Validator.validate(build_header(h), '', '  ', SECRET)
+  end
+
+  # case 12
+  def test_non_payment_topic_uses_same_algorithm
+    order_id = 'ord01abc123'
+    h = compute_hash(order_id, REQUEST_ID, TS, SECRET)
+    Validator.validate(build_header(h), REQUEST_ID, order_id, SECRET)
+  end
+
+  def test_supports_v1_when_both_present
+    header = "ts=#{TS},v1=#{valid_hash},v2=aaaa"
+    Validator.validate(header, REQUEST_ID, DATA_ID_LOWER, SECRET, supported_versions: %w[v1])
+  end
+
+  def test_only_v2_in_header_only_v1_supported_raises_missing_hash
+    header = "ts=#{TS},v2=somehash"
+    err = assert_raises(Error) do
+      Validator.validate(header, REQUEST_ID, DATA_ID_LOWER, SECRET, supported_versions: %w[v1])
+    end
+    assert_equal Reason::MISSING_HASH, err.reason
+  end
+
+  def test_empty_secret_raises_argument_error
+    assert_raises(ArgumentError) do
+      Validator.validate(build_header(valid_hash), REQUEST_ID, DATA_ID_LOWER, '')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Adds a stateless utility to verify the authenticity of incoming MercadoPago webhook notifications by recomputing the HMAC-SHA256 signature and comparing it against the `x-signature` header in constant time (timing-attack safe).

## Changes
- `lib/mercadopago/webhook/validator.rb`: HMAC-SHA256 validator with explicit secret per call, typed failure reasons
- `tests/test_webhook_signature_validator.rb`: unit tests covering success, malformed inputs, timestamp window, hash mismatch

## Test plan
- [ ] CI green