### PR TITLE
Add inline documentation and API reference links

### DIFF
--- a/lib/mercadopago.rb
+++ b/lib/mercadopago.rb
@@ -1,13 +1,33 @@
 # typed: strict
 # frozen_string_literal: true
 
+# Top-level namespace for the MercadoPago Ruby SDK.
+#
+# Provides a complete Ruby client for the MercadoPago REST API, enabling
+# payment processing, customer management, subscriptions, orders, and
+# related financial operations.
+#
+# All interaction starts through {Mercadopago::SDK}, which acts as the
+# entry point and factory for every API resource.
+#
+# @example Basic usage
+#   sdk = Mercadopago::SDK.new('YOUR_ACCESS_TOKEN')
+#   payment = sdk.payment.create({ transaction_amount: 100, ... })
+#
+# @see https://www.mercadopago.com/developers MercadoPago Developer Docs
+module Mercadopago; end
+
+# --- HTTP layer ---
 require_relative './mercadopago/http/http_client'
 
+# --- Core ---
 require_relative './mercadopago/core/mp_base'
 
+# --- Configuration ---
 require_relative './mercadopago/config/config'
 require_relative './mercadopago/config/request_options'
 
+# --- API Resources ---
 require_relative './mercadopago/resources/customer'
 require_relative './mercadopago/resources/card'
 require_relative './mercadopago/resources/user'
@@ -25,4 +45,5 @@ require_relative './mercadopago/resources/preapproval_plan'
 require_relative './mercadopago/resources/order'
 require_relative './mercadopago/resources/order_transaction'
 
+# --- Entry point ---
 require_relative './mercadopago/sdk'

--- a/lib/mercadopago/config/config.rb
+++ b/lib/mercadopago/config/config.rb
@@ -2,39 +2,64 @@
 # frozen_string_literal: true
 
 module Mercadopago
+  # Holds SDK-wide configuration constants: version, API base URL,
+  # User-Agent header, tracking identifiers, and MIME types.
+  #
+  # Instances are created internally by {MPBase} and {RequestOptions};
+  # there is no need to instantiate this class directly.
   class Config
+    # Current SDK version following SemVer.
     @@VERSION = '2.4.1'
+
+    # User-Agent string sent with every HTTP request for server-side tracking.
     @@USER_AGENT = "MercadoPago Ruby SDK v#{@@VERSION}"
+
+    # Internal product identifier registered with the MercadoPago platform.
     @@PRODUCT_ID = 'bc32a7vtrpp001u8nhjg'
+
+    # Tracking string that reports Ruby version and SDK version to the API.
     @@TRACKING_ID =  "platform:#{RUBY_VERSION},type:SDK#{@@VERSION},so;"
+
+    # Base URL for all MercadoPago REST API endpoints.
     @@API_BASE_URL = 'https://api.mercadopago.com'
+
+    # MIME type used for JSON request/response bodies.
     @@MIME_JSON = 'application/json'
+
+    # MIME type used for form-encoded request bodies.
     @@MIME_FORM = 'application/x-www-form-urlencoded'
 
+    # @return [String] current SDK version (e.g. "2.4.1")
     def version
       @@VERSION
     end
 
+    # @return [String] User-Agent header value
     def user_agent
       @@USER_AGENT
     end
 
+    # @return [String] MercadoPago internal product identifier
     def product_id
       @@PRODUCT_ID
     end
 
+    # @return [String] tracking string with Ruby and SDK versions
     def tracking_id
       @@TRACKING_ID
     end
 
+    # @return [String] MercadoPago API base URL
     def api_base_url
       @@API_BASE_URL
     end
 
+    # @return [String] JSON MIME type
     def mime_json
       @@MIME_JSON
     end
 
+    # @return [String] form-encoded MIME type
     def mime_form
       @@MIME_FORM
     end

--- a/lib/mercadopago/config/request_options.rb
+++ b/lib/mercadopago/config/request_options.rb
@@ -2,10 +2,44 @@
 # frozen_string_literal: true
 
 module Mercadopago
+  # Encapsulates per-request configuration: authentication, timeouts,
+  # retry policy, and optional MercadoPago partner/platform headers.
+  #
+  # An instance is created automatically by {SDK#initialize} but can
+  # also be built manually and passed to individual resource calls
+  # via the +request_options:+ keyword to override the SDK defaults.
+  #
+  # @example Override timeout for a single call
+  #   opts = Mercadopago::RequestOptions.new(access_token: token, connection_timeout: 120.0)
+  #   sdk.payment.get(123, request_options: opts)
   class RequestOptions
+    # @!attribute [r] access_token
+    #   @return [String, nil] OAuth access token used for Bearer authentication
+    # @!attribute [r] connection_timeout
+    #   @return [Float] HTTP timeout in seconds (default: 60.0)
+    # @!attribute [r] custom_headers
+    #   @return [Hash, nil] extra headers merged into every request
+    # @!attribute [r] corporation_id
+    #   @return [String, nil] MercadoPago corporation identifier (x-corporation-id header)
+    # @!attribute [r] integrator_id
+    #   @return [String, nil] MercadoPago integrator identifier (x-integrator-id header)
+    # @!attribute [r] platform_id
+    #   @return [String, nil] MercadoPago platform identifier (x-platform-id header)
+    # @!attribute [r] max_retries
+    #   @return [Integer] maximum automatic retries on transient HTTP errors (default: 3)
     attr_reader :access_token, :connection_timeout, :custom_headers, :corporation_id, :integrator_id,
                 :platform_id, :max_retries
 
+    # Builds a new request configuration.
+    #
+    # @param access_token [String, nil] OAuth access token
+    # @param connection_timeout [Float] HTTP timeout in seconds
+    # @param custom_headers [Hash, nil] additional headers to include
+    # @param corporation_id [String, nil] corporation identifier for partner integrations
+    # @param integrator_id [String, nil] integrator identifier for certified partners
+    # @param platform_id [String, nil] platform identifier for marketplace integrations
+    # @param max_retries [Integer] retry limit for transient failures (429, 5xx)
+    # @raise [TypeError] if any parameter is not the expected type
     def initialize(access_token: nil,
                    connection_timeout: 60.0,
                    custom_headers: nil,
@@ -24,6 +58,13 @@ module Mercadopago
       @config = Config.new
     end
 
+    # Builds the full HTTP headers hash for a request.
+    #
+    # Includes authorization, tracking, idempotency, user-agent, and
+    # any optional partner/custom headers. A unique idempotency key
+    # (UUID v4) is generated on every call.
+    #
+    # @return [Hash] merged headers ready to be sent with the HTTP request
     def get_headers
       headers = { 'Authorization': "Bearer #{@access_token}",
                   'x-product-id' => @config.product_id,
@@ -41,42 +82,56 @@ module Mercadopago
       headers
     end
 
+    # @param value [String, nil] OAuth access token
+    # @raise [TypeError] if value is not a String (nil allowed only when current value is nil)
     def access_token=(value)
       raise TypeError, 'Param access_token must be a String' unless access_token.nil? || value.is_a?(String)
 
       @access_token = value
     end
 
+    # @param value [Hash, nil] custom headers hash
+    # @raise [TypeError] if value is not a Hash or nil
     def custom_headers=(value)
       raise TypeError, 'Param custom_headers must be a Hash' unless value.nil? || value.is_a?(Hash)
 
       @custom_headers = value
     end
 
+    # @param value [Float] connection timeout in seconds
+    # @raise [TypeError] if value is not a Float
     def connection_timeout=(value)
       raise TypeError, 'Param connection_timeout must be a Float' unless value.is_a?(Float)
 
       @connection_timeout = value
     end
 
+    # @param value [String, nil] corporation identifier
+    # @raise [TypeError] if value is not a String or nil
     def corporation_id=(value)
       raise TypeError, 'Param corporation_id must be a String' unless value.nil? || value.is_a?(String)
 
       @corporation_id = value
     end
 
+    # @param value [String, nil] integrator identifier
+    # @raise [TypeError] if value is not a String or nil
     def integrator_id=(value)
       raise TypeError, 'Param integrator_id must be a String' unless value.nil? || value.is_a?(String)
 
       @integrator_id = value
     end
 
+    # @param value [String, nil] platform identifier
+    # @raise [TypeError] if value is not a String or nil
     def platform_id=(value)
       raise TypeError, 'Param platform_id must be a String' unless value.nil? || value.is_a?(String)
 
       @platform_id = value
     end
 
+    # @param value [Integer] maximum retry count
+    # @raise [TypeError] if value is not an Integer
     def max_retries=(value)
       raise TypeError, 'Param max_retries must be a Integer' unless value.is_a?(Integer)
 

--- a/lib/mercadopago/core/mp_base.rb
+++ b/lib/mercadopago/core/mp_base.rb
@@ -2,9 +2,20 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  ##
-  # Module Base
+  # Abstract base class for every API resource (Payment, Customer, Order, etc.).
+  #
+  # Provides internal HTTP helper methods (+_get+, +_post+, +_put+, +_delete+)
+  # that prepend the API base URL, inject authentication headers, serialise
+  # payloads to JSON, and delegate to {HttpClient}.
+  #
+  # Subclasses only need to call these helpers with the appropriate URI and
+  # data; they should never interact with {HttpClient} directly.
+  #
+  # @abstract Subclass and use the +_get+/+_post+/+_put+/+_delete+ helpers.
   class MPBase
+    # @param request_options [RequestOptions] authentication and request configuration
+    # @param http_client [HttpClient] transport layer for HTTP calls
+    # @raise [TypeError] if +request_options+ is not a {RequestOptions} instance
     def initialize(request_options, http_client)
       unless request_options.is_a?(RequestOptions)
         raise TypeError,
@@ -16,6 +27,15 @@ module Mercadopago
       @config = Config.new
     end
 
+    # Validates and resolves the request options for a single call.
+    #
+    # Falls back to the instance-level options when none are provided,
+    # and inherits the access token from the instance options when the
+    # override does not include one.
+    #
+    # @param request_options [RequestOptions, nil] per-call override
+    # @return [RequestOptions] resolved options ready for use
+    # @raise [TypeError] if the value is not a {RequestOptions} instance
     def _check_request_options(request_options = nil)
       request_options = @request_options if request_options.nil?
       unless request_options.is_a?(RequestOptions)
@@ -28,6 +48,11 @@ module Mercadopago
       request_options
     end
 
+    # Builds the HTTP headers hash, merging any extra headers on top.
+    #
+    # @param request_options [RequestOptions, nil] source of base headers
+    # @param extra_headers [Hash, nil] additional headers (e.g. Content-Type)
+    # @return [Hash] merged headers ready for the HTTP call
     def _check_headers(request_options = nil, extra_headers = nil)
       headers = request_options.nil? ? @request_options.get_headers : request_options.get_headers
 
@@ -36,6 +61,13 @@ module Mercadopago
       headers
     end
 
+    # Performs a GET request against the MercadoPago API.
+    #
+    # @param uri [String] API path (e.g. "/v1/payments/123")
+    # @param filters [Hash, nil] query-string parameters
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+
+    # @raise [TypeError] if +filters+ is not a Hash
     def _get(uri:, filters: nil, request_options: nil)
       raise TypeError, 'Filters must be a Hash' unless filters.nil? || filters.is_a?(Hash)
 
@@ -46,6 +78,15 @@ module Mercadopago
                        timeout: request_options.connection_timeout, maxretries: request_options.max_retries)
     end
 
+    # Performs a POST request against the MercadoPago API.
+    #
+    # Serialises +data+ to JSON before sending.
+    #
+    # @param uri [String] API path (e.g. "/v1/payments/")
+    # @param data [Hash, nil] request body (will be JSON-encoded)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+
+    # @raise [TypeError] if +data+ is not a Hash
     def _post(uri:, data:, request_options: nil)
       raise TypeError, 'Data must be a Hash' unless data.nil? || data.is_a?(Hash)
 
@@ -56,6 +97,15 @@ module Mercadopago
       @http_client.post(url: @config.api_base_url + uri, data: payload, headers: headers, timeout: request_options.connection_timeout)
     end
 
+    # Performs a PUT request against the MercadoPago API.
+    #
+    # Serialises +data+ to JSON before sending.
+    #
+    # @param uri [String] API path (e.g. "/v1/payments/123")
+    # @param data [Hash] request body (will be JSON-encoded)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+
+    # @raise [TypeError] if +data+ is not a Hash
     def _put(uri:, data:, request_options: nil)
       raise TypeError, 'Data must be a Hash' unless data.nil? || data.is_a?(Hash)
 
@@ -66,6 +116,11 @@ module Mercadopago
                        timeout: request_options.connection_timeout)
     end
 
+    # Performs a DELETE request against the MercadoPago API.
+    #
+    # @param uri [String] API path (e.g. "/v1/customers/123")
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ (response may be nil)
     def _delete(uri:, request_options: nil)
       request_options = _check_request_options(request_options)
       headers = _check_headers(request_options)

--- a/lib/mercadopago/http/http_client.rb
+++ b/lib/mercadopago/http/http_client.rb
@@ -5,7 +5,28 @@ require 'rest-client'
 require 'json'
 
 module Mercadopago
+  # Low-level HTTP transport layer built on top of RestClient.
+  #
+  # Provides the four standard HTTP verbs (GET, POST, PUT, DELETE) and
+  # normalises every response into a +{ status:, response: }+ hash.
+  # GET requests include automatic retry with a 1-second back-off for
+  # transient errors (429, 500, 502, 503, 504).
+  #
+  # This class is used internally by {MPBase}. You can subclass or
+  # replace it via +SDK.new(token, http_client: MyClient.new)+ to
+  # inject a custom transport (e.g. for testing or logging).
   class HttpClient
+    # Performs an HTTP GET request with automatic retry on transient errors.
+    #
+    # Retries up to +maxretries+ times with a 1-second sleep between
+    # attempts when the server responds with 429 or 5xx status codes.
+    #
+    # @param url [String] fully qualified URL
+    # @param headers [Hash] HTTP headers (query params can be nested under +:params+)
+    # @param params [Hash, nil] query-string parameters appended to the URL
+    # @param timeout [Float, nil] request timeout in seconds
+    # @param maxretries [Integer, nil] maximum number of retry attempts
+    # @return [Hash{Symbol => Object}] +:status+ (Integer HTTP code) and +:response+ (parsed JSON body)
     def get(url:, headers:, params: nil, timeout: nil, maxretries: nil)
       try = 0
       headers = {} if headers.nil?
@@ -30,6 +51,13 @@ module Mercadopago
       end
     end
 
+    # Performs an HTTP POST request.
+    #
+    # @param url [String] fully qualified URL
+    # @param data [String, nil] JSON-encoded request body
+    # @param headers [Hash] HTTP headers (should include Content-Type)
+    # @param timeout [Float, nil] request timeout in seconds
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ (parsed JSON body)
     def post(url:, data:, headers:, timeout: nil)
       result = RestClient::Request.execute(method: :post, url: url, payload: data, headers: headers,
                                            timeout: timeout)
@@ -44,6 +72,13 @@ module Mercadopago
       }
     end
 
+    # Performs an HTTP PUT request.
+    #
+    # @param url [String] fully qualified URL
+    # @param data [String, nil] JSON-encoded request body
+    # @param headers [Hash] HTTP headers (should include Content-Type)
+    # @param timeout [Float, nil] request timeout in seconds
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ (parsed JSON body)
     def put(url:, data:, headers:, timeout: nil)
       result = RestClient::Request.execute(method: :put, url: url, payload: data, headers: headers,
                                            timeout: timeout)
@@ -58,6 +93,15 @@ module Mercadopago
       }
     end
 
+    # Performs an HTTP DELETE request.
+    #
+    # Returns +nil+ as the response body when the server sends an empty body,
+    # which is common for successful deletions (204-style responses).
+    #
+    # @param url [String] fully qualified URL
+    # @param headers [Hash] HTTP headers
+    # @param timeout [Float, nil] request timeout in seconds
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ (parsed JSON body or nil)
     def delete(url:, headers:, timeout: nil)
       result = RestClient::Request.execute(method: 'delete', url: url, headers: headers, timeout: timeout)
       {

--- a/lib/mercadopago/resources/advanced_payment.rb
+++ b/lib/mercadopago/resources/advanced_payment.rb
@@ -9,7 +9,7 @@ module Mercadopago
   # disbursement. Supports authorization/capture flows, cancellation,
   # and release-date adjustments.
   #
-  # @see https://www.mercadopago.com/developers/en/reference/advanced_payments/_advanced_payments/post
+  # @see https://www.mercadopago.com/developers/en/reference (advanced_payments section not found in current reference)
   class AdvancedPayment < MPBase
     # Searches advanced payments matching the given filters.
     #

--- a/lib/mercadopago/resources/advanced_payment.rb
+++ b/lib/mercadopago/resources/advanced_payment.rb
@@ -2,31 +2,68 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  ###
-  # Access to Advanced Payments
-
+  # Manages advanced (split) payments for marketplace integrations.
+  #
+  # Advanced payments allow a marketplace to split a single buyer
+  # transaction across multiple sellers, each receiving their own
+  # disbursement. Supports authorization/capture flows, cancellation,
+  # and release-date adjustments.
+  #
+  # @see https://www.mercadopago.com/developers/en/reference/advanced_payments/_advanced_payments/post
   class AdvancedPayment < MPBase
+    # Searches advanced payments matching the given filters.
+    #
+    # @param filters [Hash, nil] query parameters
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with search results
+    # @raise [TypeError] if +filters+ is not a Hash
     def search(filters: nil, request_options: nil)
       raise TypeError, 'Param filters must be a Hash' unless filters.nil? || filters.is_a?(Hash)
 
       _get(uri: '/v1/advanced_payments/search', filters: filters, request_options: request_options)
     end
 
+    # Retrieves a single advanced payment by ID.
+    #
+    # @param advanced_payment_id [Integer, String] advanced payment ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with payment details
     def get(advanced_payment_id, request_options: nil)
       _get(uri: "/v1/advanced_payments/#{advanced_payment_id}", request_options: request_options)
     end
 
+    # Creates a new advanced payment with split disbursements.
+    #
+    # @param advanced_payment_data [Hash] payment attributes (payer, payments array, disbursements, etc.)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created payment
+    # @raise [TypeError] if +advanced_payment_data+ is not a Hash
     def create(advanced_payment_data, request_options: nil)
       raise TypeError, 'Param advanced_payment_data must be a Hash' unless advanced_payment_data.is_a?(Hash)
 
       _post(uri: '/v1/advanced_payments', data: advanced_payment_data, request_options: request_options)
     end
 
+    # Captures a previously authorized advanced payment.
+    #
+    # Sends +{ capture: true }+ to transition the payment from
+    # authorized to captured state.
+    #
+    # @param advanced_payment_id [Integer, String] advanced payment ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the captured payment
     def capture(advanced_payment_id, request_options: nil)
       capture_data = { capture: true }
       _put(uri: "/v1/advanced_payments/#{advanced_payment_id}", data: capture_data, request_options: request_options)
     end
 
+    # Updates an existing advanced payment.
+    #
+    # @param advanced_payment_id [Integer, String] advanced payment ID
+    # @param advanced_payment_data [Hash] fields to update
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the updated payment
+    # @raise [TypeError] if +advanced_payment_data+ is not a Hash
     def update(advanced_payment_id, advanced_payment_data, request_options: nil)
       raise TypeError, 'Param advanced_payment_data must be a Hash' unless advanced_payment_data.is_a?(Hash)
 
@@ -34,11 +71,22 @@ module Mercadopago
            request_options: request_options)
     end
 
+    # Cancels an advanced payment by setting its status to "cancelled".
+    #
+    # @param advanced_payment_id [Integer, String] advanced payment ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the cancelled payment
     def cancel(advanced_payment_id, request_options: nil)
       cancel_data = { status: 'cancelled' }
       _put(uri: "/v1/advanced_payments/#{advanced_payment_id}", data: cancel_data, request_options: request_options)
     end
 
+    # Changes the money release date for an advanced payment's disbursements.
+    #
+    # @param advanced_payment_id [Integer, String] advanced payment ID
+    # @param release_date [Time, DateTime] new release date (formatted as "%Y-%m-%d %H:%M:%S.%f")
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+
     def update_release_date(advanced_payment_id, release_date, request_options: nil)
       disbursement_data = { money_release_date: release_date.strftime('%Y-%m-%d %H:%M:%S.%f') }
       _post(uri: "/v1/advanced_payments/#{advanced_payment_id}/disburses", data: disbursement_data,

--- a/lib/mercadopago/resources/card.rb
+++ b/lib/mercadopago/resources/card.rb
@@ -8,7 +8,7 @@ module Mercadopago
   # to re-use previously tokenised card data. A card is always
   # associated with a customer ID.
   #
-  # @see https://www.mercadopago.com/developers/en/reference/cards/_customers_customer_id_cards/post
+  # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/cards/save-card/post
   class Card < MPBase
     # Retrieves a specific card saved for a customer.
     #
@@ -16,6 +16,7 @@ module Mercadopago
     # @param card_id [String] saved card ID
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with card details
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/cards/get-card/get
     def get(customer_id, card_id, request_options: nil)
       _get(uri: "/v1/customers/#{customer_id}/cards/#{card_id}", request_options: request_options)
     end
@@ -27,6 +28,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created card
     # @raise [TypeError] if +card_data+ is nil or not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/cards/save-card/post
     def create(customer_id, card_data, request_options: nil)
       raise TypeError, 'Param card_data must be a Hash' if card_data.nil? || !card_data.is_a?(Hash)
 
@@ -39,6 +41,7 @@ module Mercadopago
     # @param card_id [String] saved card ID
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/cards/delete-card/delete
     def delete(customer_id, card_id, request_options: nil)
       _delete(uri: "/v1/customers/#{customer_id}/cards/#{card_id}", request_options: request_options)
     end
@@ -48,6 +51,7 @@ module Mercadopago
     # @param customer_id [String] MercadoPago customer ID
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with an array of cards
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/cards/get-customer-cards/get
     def list(customer_id, request_options: nil)
       _get(uri: "/v1/customers/#{customer_id}/cards", request_options: request_options)
     end

--- a/lib/mercadopago/resources/card.rb
+++ b/lib/mercadopago/resources/card.rb
@@ -2,28 +2,52 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  ###
-  # The cards class is the way to store card data of your customers safely to improve the shopping experience.
-  # This will allow your customers to complete their purchases much faster and easily, since they will not have to complete their card data again.
-
-  # This class must be used in conjunction with the Customer class.
-  # [Click here for more infos](https://www.mercadopago.com/developers/en/guides/online-payments/web-tokenize-checkout/customers-and-cards)
-
+  # Manages saved cards linked to a {Customer}.
+  #
+  # Stored cards enable one-click purchases by allowing customers
+  # to re-use previously tokenised card data. A card is always
+  # associated with a customer ID.
+  #
+  # @see https://www.mercadopago.com/developers/en/reference/cards/_customers_customer_id_cards/post
   class Card < MPBase
+    # Retrieves a specific card saved for a customer.
+    #
+    # @param customer_id [String] MercadoPago customer ID
+    # @param card_id [String] saved card ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with card details
     def get(customer_id, card_id, request_options: nil)
       _get(uri: "/v1/customers/#{customer_id}/cards/#{card_id}", request_options: request_options)
     end
 
+    # Saves a new card for a customer using a previously generated card token.
+    #
+    # @param customer_id [String] MercadoPago customer ID
+    # @param card_data [Hash] card attributes (must include +token+ from {CardToken})
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created card
+    # @raise [TypeError] if +card_data+ is nil or not a Hash
     def create(customer_id, card_data, request_options: nil)
       raise TypeError, 'Param card_data must be a Hash' if card_data.nil? || !card_data.is_a?(Hash)
 
       _post(uri: "/v1/customers/#{customer_id}/cards/", data: card_data, request_options: request_options)
     end
 
+    # Deletes a saved card from a customer.
+    #
+    # @param customer_id [String] MercadoPago customer ID
+    # @param card_id [String] saved card ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+
     def delete(customer_id, card_id, request_options: nil)
       _delete(uri: "/v1/customers/#{customer_id}/cards/#{card_id}", request_options: request_options)
     end
 
+    # Lists all saved cards for a customer.
+    #
+    # @param customer_id [String] MercadoPago customer ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with an array of cards
     def list(customer_id, request_options: nil)
       _get(uri: "/v1/customers/#{customer_id}/cards", request_options: request_options)
     end

--- a/lib/mercadopago/resources/card_token.rb
+++ b/lib/mercadopago/resources/card_token.rb
@@ -8,7 +8,7 @@ module Mercadopago
   # sensitive card details when creating a payment or saving a card
   # to a {Customer}. This keeps PCI-sensitive data off your servers.
   #
-  # @see https://www.mercadopago.com/developers/en/reference/card_tokens/_card_tokens/post
+  # @see https://www.mercadopago.com/developers/en/reference
   class CardToken < MPBase
     # Retrieves an existing card token's metadata.
     #

--- a/lib/mercadopago/resources/card_token.rb
+++ b/lib/mercadopago/resources/card_token.rb
@@ -2,14 +2,29 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  ##
-  # This class will allow you to send your customers card data for Mercado Pago server and receive a token to complete the payments transactions.
-
+  # Tokenises raw card data on the MercadoPago server.
+  #
+  # The returned token is a single-use reference that replaces
+  # sensitive card details when creating a payment or saving a card
+  # to a {Customer}. This keeps PCI-sensitive data off your servers.
+  #
+  # @see https://www.mercadopago.com/developers/en/reference/card_tokens/_card_tokens/post
   class CardToken < MPBase
+    # Retrieves an existing card token's metadata.
+    #
+    # @param card_token_id [String] token ID returned by {#create}
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with token details
     def get(card_token_id, request_options: nil)
       _get(uri: "/v1/card_tokens/#{card_token_id}", request_options: request_options)
     end
 
+    # Creates a new card token from raw card data.
+    #
+    # @param card_token_data [Hash] card details (card_number, expiration_month, etc.)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the generated token
+    # @raise [TypeError] if +card_token_data+ is not a Hash
     def create(card_token_data, request_options: nil)
       raise TypeError, 'Param card_token_data must be a Hash' unless card_token_data.is_a?(Hash)
 

--- a/lib/mercadopago/resources/customer.rb
+++ b/lib/mercadopago/resources/customer.rb
@@ -2,33 +2,61 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  ###
-  # This class allows you to store customers data safely to improve the shopping experience.
-
-  # This will allow your customer to complete their purchases much faster and easily when used in conjunction with the Cards class.
-  # [Click here for more infos](https://mercadopago.com.br/developers/en/guides/online-payments/web-tokenize-checkout/customers-and-cards)
-
+  # Manages customer records for the authenticated MercadoPago account.
+  #
+  # Storing customer data enables one-click purchases when combined with
+  # the {Card} resource, which links saved cards to customers.
+  #
+  # @see https://www.mercadopago.com/developers/en/reference/customers/_customers/post
   class Customer < MPBase
+    # Searches customers matching the given filters.
+    #
+    # @param filters [Hash, nil] query parameters (e.g. +{ email: "user@example.com" }+)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with search results
     def search(filters: nil, request_options: nil)
       _get(uri: '/v1/customers/search', filters: filters, request_options: request_options)
     end
 
+    # Retrieves a single customer by ID.
+    #
+    # @param customer_id [String] MercadoPago customer ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with customer details
     def get(customer_id, request_options: nil)
       _get(uri: "/v1/customers/#{customer_id}", request_options: request_options)
     end
 
+    # Creates a new customer.
+    #
+    # @param customer_data [Hash] customer attributes (email, first_name, identification, etc.)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created customer
+    # @raise [TypeError] if +customer_data+ is not a Hash
     def create(customer_data, request_options: nil)
       raise TypeError, 'Param customer_data must be a Hash' unless customer_data.is_a?(Hash)
 
       _post(uri: '/v1/customers', data: customer_data, request_options: request_options)
     end
 
+    # Updates an existing customer.
+    #
+    # @param customer_id [String] MercadoPago customer ID
+    # @param customer_data [Hash] fields to update
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the updated customer
+    # @raise [TypeError] if +customer_data+ is not a Hash
     def update(customer_id, customer_data, request_options: nil)
       raise TypeError, 'Param customer_data must be a Hash' unless customer_data.is_a?(Hash)
 
       _put(uri: "/v1/customers/#{customer_id}", data: customer_data, request_options: request_options)
     end
 
+    # Deletes a customer permanently.
+    #
+    # @param customer_id [String] MercadoPago customer ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+
     def delete(customer_id, request_options: nil)
       _delete(uri: "/v1/customers/#{customer_id}", request_options: request_options)
     end

--- a/lib/mercadopago/resources/customer.rb
+++ b/lib/mercadopago/resources/customer.rb
@@ -7,13 +7,14 @@ module Mercadopago
   # Storing customer data enables one-click purchases when combined with
   # the {Card} resource, which links saved cards to customers.
   #
-  # @see https://www.mercadopago.com/developers/en/reference/customers/_customers/post
+  # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/customers/create-customer/post
   class Customer < MPBase
     # Searches customers matching the given filters.
     #
     # @param filters [Hash, nil] query parameters (e.g. +{ email: "user@example.com" }+)
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with search results
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/customers/search-customer/get
     def search(filters: nil, request_options: nil)
       _get(uri: '/v1/customers/search', filters: filters, request_options: request_options)
     end
@@ -23,6 +24,7 @@ module Mercadopago
     # @param customer_id [String] MercadoPago customer ID
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with customer details
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/customers/get-customer/get
     def get(customer_id, request_options: nil)
       _get(uri: "/v1/customers/#{customer_id}", request_options: request_options)
     end
@@ -33,6 +35,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created customer
     # @raise [TypeError] if +customer_data+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/customers/create-customer/post
     def create(customer_data, request_options: nil)
       raise TypeError, 'Param customer_data must be a Hash' unless customer_data.is_a?(Hash)
 
@@ -46,6 +49,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the updated customer
     # @raise [TypeError] if +customer_data+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/customers/update-customer/put
     def update(customer_id, customer_data, request_options: nil)
       raise TypeError, 'Param customer_data must be a Hash' unless customer_data.is_a?(Hash)
 

--- a/lib/mercadopago/resources/disbursement_refund.rb
+++ b/lib/mercadopago/resources/disbursement_refund.rb
@@ -2,18 +2,40 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  #     ###
-  #     #Access to Advanced Payments Refunds
-
+  # Manages refunds on individual disbursements within an {AdvancedPayment}.
+  #
+  # In marketplace split-payment scenarios each seller receives a
+  # separate disbursement. This resource allows refunding one specific
+  # disbursement (full or partial) or all disbursements at once.
   class DisbursementRefund < MPBase
+    # Lists all refunds for an advanced payment.
+    #
+    # @param advanced_payment_id [Integer, String] advanced payment ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with an array of refunds
     def list(advanced_payment_id, request_options: nil)
       _get(uri: "/v1/advanced_payments/#{advanced_payment_id}/refunds", request_options: nil)
     end
 
+    # Refunds all disbursements of an advanced payment at once.
+    #
+    # @param advanced_payment_id [Integer, String] advanced payment ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with refund details
     def create_all(advanced_payment_id, request_options: nil)
       _post(uri: "/v1/advanced_payments/#{advanced_payment_id}/refunds", request_options: request_options)
     end
 
+    # Refunds a single disbursement (full or partial).
+    #
+    # Omit +amount+ for a full refund of the disbursement, or pass a
+    # specific amount for a partial refund.
+    #
+    # @param advanced_payment_id [Integer, String] advanced payment ID
+    # @param disbursement_id [Integer, String] disbursement ID within the advanced payment
+    # @param amount [Float, nil] partial refund amount; nil for a full refund
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created refund
     def create(advanced_payment_id, disbursement_id, amount: nil, request_options: nil)
       disbursement_refund_data = amount.nil? ? nil : { amount: amount }
 

--- a/lib/mercadopago/resources/identification_type.rb
+++ b/lib/mercadopago/resources/identification_type.rb
@@ -2,10 +2,18 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  ###
-  # Access to Identification Types
-
+  # Lists the identification document types accepted in each country
+  # (e.g. CPF in Brazil, DNI in Argentina).
+  #
+  # The returned list is used to populate identification-type selectors
+  # in checkout forms and to validate payer documents.
+  #
+  # @see https://www.mercadopago.com/developers/en/reference/identification_types/_identification_types/get
   class IdentificationType < MPBase
+    # Retrieves all identification types available for the caller's country.
+    #
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with an array of identification types
     def get(request_options: nil)
       _get(uri: '/v1/identification_types', request_options: request_options)
     end

--- a/lib/mercadopago/resources/identification_type.rb
+++ b/lib/mercadopago/resources/identification_type.rb
@@ -8,12 +8,13 @@ module Mercadopago
   # The returned list is used to populate identification-type selectors
   # in checkout forms and to validate payer documents.
   #
-  # @see https://www.mercadopago.com/developers/en/reference/identification_types/_identification_types/get
+  # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/identification-types/get
   class IdentificationType < MPBase
     # Retrieves all identification types available for the caller's country.
     #
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with an array of identification types
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/identification-types/get
     def get(request_options: nil)
       _get(uri: '/v1/identification_types', request_options: request_options)
     end

--- a/lib/mercadopago/resources/merchant_order.rb
+++ b/lib/mercadopago/resources/merchant_order.rb
@@ -2,26 +2,54 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  ###
-  # This class will allow you to create and manage your orders. You can attach one or more payments in your merchant order.
-
+  # Groups one or more payments into a single merchant order.
+  #
+  # Merchant orders are useful for marketplace and multi-payment
+  # scenarios where you need to track the fulfilment status of
+  # several payments as a unit.
+  #
+  # @see https://www.mercadopago.com/developers/en/reference/merchant_orders/_merchant_orders/post
   class MerchantOrder < MPBase
+    # Searches merchant orders matching the given filters.
+    #
+    # @param filters [Hash, nil] query parameters
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with search results
+    # @raise [TypeError] if +filters+ is not a Hash
     def search(filters: nil, request_options: nil)
       raise TypeError, 'Param filters must be a Hash' unless filters.nil? || filters.is_a?(Hash)
 
       _get(uri: '/merchant_orders/search', filters: filters, request_options: request_options)
     end
 
+    # Retrieves a single merchant order by ID.
+    #
+    # @param merchant_order_id [Integer, String] merchant order ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with order details
     def get(merchant_order_id, request_options: nil)
       _get(uri: "/merchant_orders/#{merchant_order_id}", request_options: request_options)
     end
 
+    # Creates a new merchant order.
+    #
+    # @param merchant_order_data [Hash] order attributes (items, preference_id, etc.)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created order
+    # @raise [TypeError] if +merchant_order_data+ is not a Hash
     def create(merchant_order_data, request_options: nil)
       raise TypeError, 'Param merchant_orders_object must be a Hash' unless merchant_order_data.is_a?(Hash)
 
       _post(uri: '/merchant_orders', data: merchant_order_data, request_options: request_options)
     end
 
+    # Updates an existing merchant order.
+    #
+    # @param merchant_order_id [Integer, String] merchant order ID
+    # @param merchant_order_data [Hash] fields to update
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the updated order
+    # @raise [TypeError] if +merchant_order_data+ is not a Hash
     def update(merchant_order_id, merchant_order_data, request_options: nil)
       raise TypeError, 'Param merchant_orders_object must be a Hash' unless merchant_order_data.is_a?(Hash)
 

--- a/lib/mercadopago/resources/merchant_order.rb
+++ b/lib/mercadopago/resources/merchant_order.rb
@@ -8,7 +8,7 @@ module Mercadopago
   # scenarios where you need to track the fulfilment status of
   # several payments as a unit.
   #
-  # @see https://www.mercadopago.com/developers/en/reference/merchant_orders/_merchant_orders/post
+  # @see https://www.mercadopago.com/developers/en/reference/
   class MerchantOrder < MPBase
     # Searches merchant orders matching the given filters.
     #
@@ -16,6 +16,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with search results
     # @raise [TypeError] if +filters+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-pro/merchant_orders/search-merchant-order/get
     def search(filters: nil, request_options: nil)
       raise TypeError, 'Param filters must be a Hash' unless filters.nil? || filters.is_a?(Hash)
 
@@ -27,6 +28,7 @@ module Mercadopago
     # @param merchant_order_id [Integer, String] merchant order ID
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with order details
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-pro/merchant_orders/get-merchant-order/get
     def get(merchant_order_id, request_options: nil)
       _get(uri: "/merchant_orders/#{merchant_order_id}", request_options: request_options)
     end
@@ -37,6 +39,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created order
     # @raise [TypeError] if +merchant_order_data+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/
     def create(merchant_order_data, request_options: nil)
       raise TypeError, 'Param merchant_orders_object must be a Hash' unless merchant_order_data.is_a?(Hash)
 
@@ -50,6 +53,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the updated order
     # @raise [TypeError] if +merchant_order_data+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-pro/merchant_orders/update-merchant-order/put
     def update(merchant_order_id, merchant_order_data, request_options: nil)
       raise TypeError, 'Param merchant_orders_object must be a Hash' unless merchant_order_data.is_a?(Hash)
 

--- a/lib/mercadopago/resources/order.rb
+++ b/lib/mercadopago/resources/order.rb
@@ -2,28 +2,55 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  ###
-  # This class provides the methods to access the API that will allow you to create an order on your website
-
-  # From basic to advanced configurations, you control the whole experience.
-
-  # [Click here for more infos](https://www.mercadopago.com/developers/en/docs/checkout-api/landing)
-
+  # Manages orders through the Checkout API v1.
+  #
+  # An order groups one or more transactions and supports the full
+  # lifecycle: create, process, capture, refund, cancel, and search.
+  # Use {OrderTransaction} to manage individual transactions within
+  # an order.
+  #
+  # @see https://www.mercadopago.com/developers/en/docs/checkout-api/landing
   class Order < MPBase
+    # Creates a new order.
+    #
+    # @param order_data [Hash] order attributes (type, total_amount, transactions, etc.)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created order
+    # @raise [TypeError] if +order_data+ is not a Hash
     def create(order_data, request_options: nil)
       raise TypeError, 'Param order_data must be a Hash' unless order_data.is_a?(Hash)
 
       _post(uri: '/v1/orders', data: order_data, request_options: request_options)
     end
 
+    # Retrieves a single order by ID.
+    #
+    # @param order_id [String] order ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with order details
     def get(order_id, request_options: nil)
       _get(uri: "/v1/orders/#{order_id}", request_options: request_options)
     end
 
+    # Processes (confirms) an order, triggering payment execution.
+    #
+    # @param order_id [String] order ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the processed order
     def process(order_id, request_options: nil)
       _post(uri: "/v1/orders/#{order_id}/process", data: nil,request_options: request_options)
     end
 
+    # Refunds an order (full or partial).
+    #
+    # Omit +refund_data+ for a full refund, or pass +{ amount: 10.0 }+
+    # for a partial refund.
+    #
+    # @param order_id [String] order ID
+    # @param refund_data [Hash, nil] optional refund attributes
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the refund result
+    # @raise [TypeError] if +refund_data+ is provided but is not a Hash
     def refund(order_id, refund_data: nil, request_options: nil)
       unless refund_data.nil?
         raise TypeError, 'Param refund_data must be a Hash' unless refund_data.is_a?(Hash)
@@ -32,14 +59,29 @@ module Mercadopago
       _post(uri: "/v1/orders/#{order_id}/refund", data: refund_data, request_options: request_options)
     end
 
+    # Cancels an order that has not yet been captured.
+    #
+    # @param order_id [String] order ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the cancelled order
     def cancel(order_id, request_options: nil)
       _post(uri: "/v1/orders/#{order_id}/cancel", data: nil, request_options: request_options)
     end
 
+    # Captures a previously authorized order.
+    #
+    # @param order_id [String] order ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the captured order
     def capture(order_id, request_options: nil)
       _post(uri: "/v1/orders/#{order_id}/capture", data: nil, request_options: request_options)
     end
 
+    # Searches orders matching the given filters.
+    #
+    # @param filters [Hash, nil] query parameters
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with search results
     def search(filters: nil, request_options: nil)
       _get(uri: '/v1/orders', params: filters, request_options: request_options)
     end

--- a/lib/mercadopago/resources/order_transaction.rb
+++ b/lib/mercadopago/resources/order_transaction.rb
@@ -3,26 +3,47 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  ###
-  # This class provides the methods to access the API that will allow you to create an order transaction on your website
-
-  # From basic to advanced configurations, you control the whole experience.
-
-  # [Click here for more infos](https://www.mercadopago.com/developers/en/docs/checkout-api/landing)
-
+  # Manages individual transactions within an {Order}.
+  #
+  # Each transaction represents a payment attempt or payment method
+  # attached to an order. You can add, update, or remove transactions
+  # before the order is processed.
+  #
+  # @see https://www.mercadopago.com/developers/en/docs/checkout-api/landing
   class OrderTransaction < MPBase
+    # Adds a new transaction to an order.
+    #
+    # @param order_id [String] parent order ID
+    # @param order_transaction_data [Hash] transaction attributes (payment method, amount, etc.)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created transaction
+    # @raise [TypeError] if +order_transaction_data+ is not a Hash
     def create(order_id, order_transaction_data, request_options: nil)
       raise TypeError, 'Param order_transaction_data must be a Hash' unless order_transaction_data.is_a?(Hash)
 
       _post(uri: "/v1/orders/#{order_id}/transactions", data: order_transaction_data, request_options: request_options)
     end
 
+    # Updates an existing transaction within an order.
+    #
+    # @param order_id [String] parent order ID
+    # @param transaction_id [String] transaction ID to update
+    # @param order_transaction_data [Hash] fields to update
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the updated transaction
+    # @raise [TypeError] if +order_transaction_data+ is not a Hash
     def update(order_id, transaction_id, order_transaction_data, request_options: nil)
       raise TypeError, 'Param order_transaction_data must be a Hash' unless order_transaction_data.is_a?(Hash)
 
       _put(uri: "/v1/orders/#{order_id}/transactions/#{transaction_id}", data: order_transaction_data, request_options: request_options)
     end
 
+    # Removes a transaction from an order.
+    #
+    # @param order_id [String] parent order ID
+    # @param transaction_id [String] transaction ID to delete
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+
     def delete(order_id, transaction_id, request_options: nil)
       _delete(uri: "/v1/orders/#{order_id}/transactions/#{transaction_id}", request_options: request_options)
     end

--- a/lib/mercadopago/resources/payment.rb
+++ b/lib/mercadopago/resources/payment.rb
@@ -7,7 +7,7 @@ module Mercadopago
   # Supports the full payment lifecycle: create, retrieve, search, and
   # update. Use this resource to build custom checkout experiences.
   #
-  # @see https://www.mercadopago.com/developers/en/reference/payments/_payments/post
+  # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api-payments/create-payment/post
   class Payment < MPBase
     # Searches payments matching the given filters.
     #
@@ -15,6 +15,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with search results
     # @raise [TypeError] if +filters+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api-payments/search-payments/get
     def search(filters: nil, request_options: nil)
       raise TypeError, 'Param filters must be a Hash' unless filters.nil? || filters.is_a?(Hash)
 
@@ -26,6 +27,7 @@ module Mercadopago
     # @param payment_id [Integer, String] MercadoPago payment ID
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with payment details
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api-payments/get-payment/get
     def get(payment_id, request_options: nil)
       _get(uri: "/v1/payments/#{payment_id}", request_options: request_options)
     end
@@ -36,6 +38,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created payment
     # @raise [TypeError] if +payment_data+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api-payments/create-payment/post
     def create(payment_data, request_options: nil)
       raise TypeError, 'Param payment_data must be a Hash' unless payment_data.is_a?(Hash)
 
@@ -49,6 +52,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the updated payment
     # @raise [TypeError] if +payment_data+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api-payments/update-payment/put
     def update(payment_id, payment_data, request_options: nil)
       raise TypeError, 'Param payment_data must be a Hash' unless payment_data.is_a?(Hash)
 

--- a/lib/mercadopago/resources/payment.rb
+++ b/lib/mercadopago/resources/payment.rb
@@ -2,30 +2,53 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  ###
-  # This class provides the methods to access the API that will allow you to create your own payment experience on your website.
-
-  # From basic to advanced configurations, you control the whole experience.
-
-  # [Click here for more infos](https://www.mercadopago.com.br/developers/en/guides/online-payments/checkout-api/introduction/)
-
+  # Manages payment operations through the Checkout API.
+  #
+  # Supports the full payment lifecycle: create, retrieve, search, and
+  # update. Use this resource to build custom checkout experiences.
+  #
+  # @see https://www.mercadopago.com/developers/en/reference/payments/_payments/post
   class Payment < MPBase
+    # Searches payments matching the given filters.
+    #
+    # @param filters [Hash, nil] query parameters (e.g. +{ status: "approved", external_reference: "ref" }+)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with search results
+    # @raise [TypeError] if +filters+ is not a Hash
     def search(filters: nil, request_options: nil)
       raise TypeError, 'Param filters must be a Hash' unless filters.nil? || filters.is_a?(Hash)
 
       _get(uri: '/v1/payments/search', filters: filters, request_options: request_options)
     end
 
+    # Retrieves a single payment by its ID.
+    #
+    # @param payment_id [Integer, String] MercadoPago payment ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with payment details
     def get(payment_id, request_options: nil)
       _get(uri: "/v1/payments/#{payment_id}", request_options: request_options)
     end
 
+    # Creates a new payment.
+    #
+    # @param payment_data [Hash] payment attributes (amount, payer, payment_method, etc.)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created payment
+    # @raise [TypeError] if +payment_data+ is not a Hash
     def create(payment_data, request_options: nil)
       raise TypeError, 'Param payment_data must be a Hash' unless payment_data.is_a?(Hash)
 
       _post(uri: '/v1/payments/', data: payment_data, request_options: request_options)
     end
 
+    # Updates an existing payment (e.g. capture an authorized payment).
+    #
+    # @param payment_id [Integer, String] MercadoPago payment ID
+    # @param payment_data [Hash] fields to update
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the updated payment
+    # @raise [TypeError] if +payment_data+ is not a Hash
     def update(payment_id, payment_data, request_options: nil)
       raise TypeError, 'Param payment_data must be a Hash' unless payment_data.is_a?(Hash)
 

--- a/lib/mercadopago/resources/payment_methods.rb
+++ b/lib/mercadopago/resources/payment_methods.rb
@@ -8,12 +8,13 @@ module Mercadopago
   # Useful for building dynamic checkout forms that only show the methods
   # the buyer can actually use.
   #
-  # @see https://www.mercadopago.com/developers/en/reference/payment_methods/_payment_methods/get
+  # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/payment-methods/get
   class PaymentMethods < MPBase
     # Retrieves all payment methods available for the authenticated account.
     #
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with an array of payment methods
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/payment-methods/get
     def get(request_options: nil)
       _get(uri: '/v1/payment_methods', request_options: request_options)
     end

--- a/lib/mercadopago/resources/payment_methods.rb
+++ b/lib/mercadopago/resources/payment_methods.rb
@@ -2,10 +2,18 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  ###
-  # Access to Payment Methods
-
+  # Lists the payment methods available for the caller's MercadoPago site
+  # (credit cards, debit cards, bank transfer, cash, etc.).
+  #
+  # Useful for building dynamic checkout forms that only show the methods
+  # the buyer can actually use.
+  #
+  # @see https://www.mercadopago.com/developers/en/reference/payment_methods/_payment_methods/get
   class PaymentMethods < MPBase
+    # Retrieves all payment methods available for the authenticated account.
+    #
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with an array of payment methods
     def get(request_options: nil)
       _get(uri: '/v1/payment_methods', request_options: request_options)
     end

--- a/lib/mercadopago/resources/preapproval.rb
+++ b/lib/mercadopago/resources/preapproval.rb
@@ -2,31 +2,55 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  ###
-  # This class provides the methods to access the API
-  # that will allow you to create your own subscription experience on your website.
-
-  # From basic to advanced configurations, you control the whole experience.
-
-  # [Click here for more infos](https://www.mercadopago.com.ar/developers/es/reference/subscriptions/_preapproval/post)
-
+  # Manages recurring subscriptions (preapprovals).
+  #
+  # A preapproval authorises MercadoPago to charge the buyer
+  # periodically according to the terms defined by a
+  # {PreapprovalPlan}. Use this resource to create, update, pause,
+  # or cancel individual subscriptions.
+  #
+  # @see https://www.mercadopago.com/developers/en/reference/subscriptions/_preapproval/post
   class Preapproval < MPBase
+    # Searches subscriptions matching the given filters.
+    #
+    # @param filters [Hash, nil] query parameters (e.g. +{ status: "authorized" }+)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with search results
+    # @raise [TypeError] if +filters+ is not a Hash
     def search(filters: nil, request_options: nil)
       raise TypeError, 'Param filters must be a Hash' unless filters.nil? || filters.is_a?(Hash)
 
       _get(uri: '/preapproval/search', filters: filters, request_options: request_options)
     end
 
+    # Retrieves a single subscription by ID.
+    #
+    # @param preapproval_id [String] subscription ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with subscription details
     def get(preapproval_id, request_options: nil)
       _get(uri: "/preapproval/#{preapproval_id}", request_options: request_options)
     end
 
+    # Creates a new subscription.
+    #
+    # @param preapproval_data [Hash] subscription attributes (plan_id, payer_email, etc.)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created subscription
+    # @raise [TypeError] if +preapproval_data+ is not a Hash
     def create(preapproval_data, request_options: nil)
       raise TypeError, 'Param preapproval_data must be a Hash' unless preapproval_data.is_a?(Hash)
 
       _post(uri: '/preapproval/', data: preapproval_data, request_options: request_options)
     end
 
+    # Updates an existing subscription (e.g. pause, resume, or cancel).
+    #
+    # @param preapproval_id [String] subscription ID
+    # @param preapproval_data [Hash] fields to update (e.g. +{ status: "paused" }+)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the updated subscription
+    # @raise [TypeError] if +preapproval_data+ is not a Hash
     def update(preapproval_id, preapproval_data, request_options: nil)
       raise TypeError, 'Param preapproval_data must be a Hash' unless preapproval_data.is_a?(Hash)
 

--- a/lib/mercadopago/resources/preapproval.rb
+++ b/lib/mercadopago/resources/preapproval.rb
@@ -9,7 +9,7 @@ module Mercadopago
   # {PreapprovalPlan}. Use this resource to create, update, pause,
   # or cancel individual subscriptions.
   #
-  # @see https://www.mercadopago.com/developers/en/reference/subscriptions/_preapproval/post
+  # @see https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/create-preapproval/post
   class Preapproval < MPBase
     # Searches subscriptions matching the given filters.
     #
@@ -17,6 +17,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with search results
     # @raise [TypeError] if +filters+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/search-preapproval/get
     def search(filters: nil, request_options: nil)
       raise TypeError, 'Param filters must be a Hash' unless filters.nil? || filters.is_a?(Hash)
 
@@ -28,6 +29,7 @@ module Mercadopago
     # @param preapproval_id [String] subscription ID
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with subscription details
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/get-preapproval/get
     def get(preapproval_id, request_options: nil)
       _get(uri: "/preapproval/#{preapproval_id}", request_options: request_options)
     end
@@ -38,6 +40,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created subscription
     # @raise [TypeError] if +preapproval_data+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/create-preapproval/post
     def create(preapproval_data, request_options: nil)
       raise TypeError, 'Param preapproval_data must be a Hash' unless preapproval_data.is_a?(Hash)
 
@@ -51,6 +54,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the updated subscription
     # @raise [TypeError] if +preapproval_data+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/update-preapproval/put
     def update(preapproval_id, preapproval_data, request_options: nil)
       raise TypeError, 'Param preapproval_data must be a Hash' unless preapproval_data.is_a?(Hash)
 

--- a/lib/mercadopago/resources/preapproval_plan.rb
+++ b/lib/mercadopago/resources/preapproval_plan.rb
@@ -2,31 +2,54 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  ###
-  # This class provides the methods to access the API
-  # that will allow you to create your own plan of subscription experience on your website.
-
-  # From basic to advanced configurations, you control the whole experience.
-
-  # [Click here for more infos](https://www.mercadopago.com.ar/developers/es/reference/subscriptions/_preapproval_plan/post)
-
+  # Manages subscription plan templates (preapproval plans).
+  #
+  # A plan defines the recurring billing terms (frequency, amount,
+  # currency) that one or more {Preapproval} subscriptions can
+  # reference. Create a plan once, then associate subscribers to it.
+  #
+  # @see https://www.mercadopago.com/developers/en/reference/subscriptions/_preapproval_plan/post
   class PreapprovalPlan < MPBase
+    # Searches subscription plans matching the given filters.
+    #
+    # @param filters [Hash, nil] query parameters
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with search results
+    # @raise [TypeError] if +filters+ is not a Hash
     def search(filters: nil, request_options: nil)
       raise TypeError, 'Param filters must be a Hash' unless filters.nil? || filters.is_a?(Hash)
 
       _get(uri: '/preapproval_plan/search', filters: filters, request_options: request_options)
     end
 
+    # Retrieves a single subscription plan by ID.
+    #
+    # @param preapproval_plan_id [String] plan ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with plan details
     def get(preapproval_plan_id, request_options: nil)
       _get(uri: "/preapproval_plan/#{preapproval_plan_id}", request_options: request_options)
     end
 
+    # Creates a new subscription plan.
+    #
+    # @param preapproval_plan_data [Hash] plan attributes (reason, auto_recurring, back_url, etc.)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created plan
+    # @raise [TypeError] if +preapproval_plan_data+ is not a Hash
     def create(preapproval_plan_data, request_options: nil)
       raise TypeError, 'Param preapproval_plan_data must be a Hash' unless preapproval_plan_data.is_a?(Hash)
 
       _post(uri: '/preapproval_plan/', data: preapproval_plan_data, request_options: request_options)
     end
 
+    # Updates an existing subscription plan.
+    #
+    # @param preapproval_plan_id [String] plan ID
+    # @param preapproval_plan_data [Hash] fields to update
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the updated plan
+    # @raise [TypeError] if +preapproval_plan_data+ is not a Hash
     def update(preapproval_plan_id, preapproval_plan_data, request_options: nil)
       raise TypeError, 'Param preapproval_plan_data must be a Hash' unless preapproval_plan_data.is_a?(Hash)
 

--- a/lib/mercadopago/resources/preapproval_plan.rb
+++ b/lib/mercadopago/resources/preapproval_plan.rb
@@ -8,7 +8,7 @@ module Mercadopago
   # currency) that one or more {Preapproval} subscriptions can
   # reference. Create a plan once, then associate subscribers to it.
   #
-  # @see https://www.mercadopago.com/developers/en/reference/subscriptions/_preapproval_plan/post
+  # @see https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/create-preapproval-plan/post
   class PreapprovalPlan < MPBase
     # Searches subscription plans matching the given filters.
     #
@@ -16,6 +16,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with search results
     # @raise [TypeError] if +filters+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/search-preapproval-plan/get
     def search(filters: nil, request_options: nil)
       raise TypeError, 'Param filters must be a Hash' unless filters.nil? || filters.is_a?(Hash)
 
@@ -27,6 +28,7 @@ module Mercadopago
     # @param preapproval_plan_id [String] plan ID
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with plan details
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/get-preapproval-plan/get
     def get(preapproval_plan_id, request_options: nil)
       _get(uri: "/preapproval_plan/#{preapproval_plan_id}", request_options: request_options)
     end
@@ -37,6 +39,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created plan
     # @raise [TypeError] if +preapproval_plan_data+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/create-preapproval-plan/post
     def create(preapproval_plan_data, request_options: nil)
       raise TypeError, 'Param preapproval_plan_data must be a Hash' unless preapproval_plan_data.is_a?(Hash)
 
@@ -50,6 +53,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the updated plan
     # @raise [TypeError] if +preapproval_plan_data+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/update-preapproval-plan/put
     def update(preapproval_plan_id, preapproval_plan_data, request_options: nil)
       raise TypeError, 'Param preapproval_plan_data must be a Hash' unless preapproval_plan_data.is_a?(Hash)
 

--- a/lib/mercadopago/resources/preference.rb
+++ b/lib/mercadopago/resources/preference.rb
@@ -2,21 +2,42 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  ##
-  # This class will allow you to charge your customers through our web form from any device in a simple, fast and secure way.
-  # [Click here for more infos](https://www.mercadopago.com.br/developers/en/guides/online-payments/checkout-pro/introduction)
-
+  # Manages Checkout Pro payment preferences.
+  #
+  # A preference defines the items, payer info, redirect URLs, and
+  # payment configuration for a Checkout Pro session. The API returns
+  # an +init_point+ URL that redirects the buyer to the hosted checkout.
+  #
+  # @see https://www.mercadopago.com/developers/en/reference/preferences/_checkout_preferences/post
   class Preference < MPBase
+    # Retrieves an existing preference.
+    #
+    # @param preference_id [String] preference ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with preference details
     def get(preference_id, request_options: nil)
       _get(uri: "/checkout/preferences/#{preference_id}", request_options: request_options)
     end
 
+    # Creates a new Checkout Pro preference.
+    #
+    # @param preference_data [Hash] preference attributes (items, payer, back_urls, etc.)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created preference (includes +init_point+)
+    # @raise [TypeError] if +preference_data+ is not a Hash
     def create(preference_data, request_options: nil)
       raise TypeError, 'Param preference_data must be a Hash' unless preference_data.is_a?(Hash)
 
       _post(uri: '/checkout/preferences', data: preference_data, request_options: request_options)
     end
 
+    # Updates an existing preference.
+    #
+    # @param preference_id [String] preference ID
+    # @param preference_data [Hash] fields to update
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the updated preference
+    # @raise [TypeError] if +preference_data+ is not a Hash
     def update(preference_id, preference_data, request_options: nil)
       raise TypeError, 'Param preference_data must be a Hash' unless preference_data.is_a?(Hash)
 

--- a/lib/mercadopago/resources/preference.rb
+++ b/lib/mercadopago/resources/preference.rb
@@ -8,13 +8,14 @@ module Mercadopago
   # payment configuration for a Checkout Pro session. The API returns
   # an +init_point+ URL that redirects the buyer to the hosted checkout.
   #
-  # @see https://www.mercadopago.com/developers/en/reference/preferences/_checkout_preferences/post
+  # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-pro/preferences/create-preference/post
   class Preference < MPBase
     # Retrieves an existing preference.
     #
     # @param preference_id [String] preference ID
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with preference details
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-pro/preferences/get-preference/get
     def get(preference_id, request_options: nil)
       _get(uri: "/checkout/preferences/#{preference_id}", request_options: request_options)
     end
@@ -25,6 +26,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created preference (includes +init_point+)
     # @raise [TypeError] if +preference_data+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-pro/preferences/create-preference/post
     def create(preference_data, request_options: nil)
       raise TypeError, 'Param preference_data must be a Hash' unless preference_data.is_a?(Hash)
 
@@ -38,6 +40,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the updated preference
     # @raise [TypeError] if +preference_data+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-pro/preferences/update-preference/put
     def update(preference_id, preference_data, request_options: nil)
       raise TypeError, 'Param preference_data must be a Hash' unless preference_data.is_a?(Hash)
 

--- a/lib/mercadopago/resources/refund.rb
+++ b/lib/mercadopago/resources/refund.rb
@@ -8,13 +8,14 @@ module Mercadopago
   # The seller's account must hold enough funds to cover the refund;
   # otherwise the API returns a 400 Bad Request.
   #
-  # @see https://www.mercadopago.com/developers/en/reference/chargebacks/_payments_id_refunds/post
+  # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api-payments/create-refund/post
   class Refund < MPBase
     # Lists all refunds for a given payment.
     #
     # @param payment_id [Integer, String] MercadoPago payment ID
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with an array of refunds
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api-payments/get-refunds/get
     def list(payment_id, request_options: nil)
       _get(uri: "/v1/payments/#{payment_id}/refunds", request_options: request_options)
     end
@@ -29,6 +30,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created refund
     # @raise [TypeError] if +refund_data+ is not a Hash
+    # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api-payments/create-refund/post
     def create(payment_id, refund_data: nil, request_options: nil)
       raise TypeError, 'Param refund_data must be a Hash' unless refund_data.nil? || refund_data.is_a?(Hash)
 

--- a/lib/mercadopago/resources/refund.rb
+++ b/lib/mercadopago/resources/refund.rb
@@ -2,19 +2,33 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  ###
-  # This class will allow you to refund payments created through the Payments class.
-  # You can refund a payment within 180 days after it was approved.
-
-  # You must have sufficient funds in your account in order to successfully refund the payment amount. Otherwise, you will get a 400 Bad Request error.
-
-  # [Click here for more infos](https://www.mercadopago.com.br/developers/en/guides/manage-account/account/cancellations-and-refunds#bookmark_refunds)
-
+  # Issues full or partial refunds on approved payments.
+  #
+  # Refunds can be created within 180 days of payment approval.
+  # The seller's account must hold enough funds to cover the refund;
+  # otherwise the API returns a 400 Bad Request.
+  #
+  # @see https://www.mercadopago.com/developers/en/reference/chargebacks/_payments_id_refunds/post
   class Refund < MPBase
+    # Lists all refunds for a given payment.
+    #
+    # @param payment_id [Integer, String] MercadoPago payment ID
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with an array of refunds
     def list(payment_id, request_options: nil)
       _get(uri: "/v1/payments/#{payment_id}/refunds", request_options: request_options)
     end
 
+    # Creates a full or partial refund on a payment.
+    #
+    # Omit +refund_data+ for a full refund, or pass +{ amount: 10.0 }+
+    # for a partial refund.
+    #
+    # @param payment_id [Integer, String] MercadoPago payment ID
+    # @param refund_data [Hash, nil] optional refund attributes (e.g. +{ amount: 10.0 }+)
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created refund
+    # @raise [TypeError] if +refund_data+ is not a Hash
     def create(payment_id, refund_data: nil, request_options: nil)
       raise TypeError, 'Param refund_data must be a Hash' unless refund_data.nil? || refund_data.is_a?(Hash)
 

--- a/lib/mercadopago/resources/user.rb
+++ b/lib/mercadopago/resources/user.rb
@@ -2,10 +2,17 @@
 # frozen_string_literal: true
 
 module Mercadopago
-  ###
-  # Access to Users
-
+  # Retrieves the profile of the currently authenticated MercadoPago user.
+  #
+  # Useful for validating the access token and obtaining the seller's
+  # account details (ID, email, site, country, etc.).
+  #
+  # @see https://www.mercadopago.com/developers/en/reference/users/_users_me/get
   class User < MPBase
+    # Returns the authenticated user's profile.
+    #
+    # @param request_options [RequestOptions, nil] per-call configuration override
+    # @return [Hash{Symbol => Object}] +:status+ and +:response+ with user profile data
     def get(request_options: nil)
       _get(uri: '/users/me', request_options: request_options)
     end

--- a/lib/mercadopago/resources/user.rb
+++ b/lib/mercadopago/resources/user.rb
@@ -7,7 +7,7 @@ module Mercadopago
   # Useful for validating the access token and obtaining the seller's
   # account details (ID, email, site, country, etc.).
   #
-  # @see https://www.mercadopago.com/developers/en/reference/users/_users_me/get
+  # @see https://www.mercadopago.com/developers/en/reference (users section not found in current reference)
   class User < MPBase
     # Returns the authenticated user's profile.
     #

--- a/lib/mercadopago/sdk.rb
+++ b/lib/mercadopago/sdk.rb
@@ -2,98 +2,152 @@
 # frozen_string_literal: true
 
 module Mercadopago
+  # Main entry point and factory for the MercadoPago Ruby SDK.
+  #
+  # Holds the OAuth access token, the HTTP transport, and the request
+  # configuration. Every API resource is exposed as a method that returns
+  # a ready-to-use resource instance (e.g. +sdk.payment+, +sdk.customer+).
+  #
+  # @example Minimal setup
+  #   sdk = Mercadopago::SDK.new('APP_ACCESS_TOKEN')
+  #   result = sdk.payment.create(transaction_amount: 100, ...)
+  #
+  # @example With custom options
+  #   opts = Mercadopago::RequestOptions.new(
+  #     access_token: 'APP_ACCESS_TOKEN',
+  #     connection_timeout: 120.0,
+  #     integrator_id: 'INTEGRATOR_ID'
+  #   )
+  #   sdk = Mercadopago::SDK.new('APP_ACCESS_TOKEN', request_options: opts)
   class SDK
+    # @!attribute [r] access_token
+    #   @return [String] OAuth access token used for API authentication
+    # @!attribute [r] http_client
+    #   @return [HttpClient] HTTP transport layer
     attr_reader :access_token, :http_client
 
+    # Creates a new SDK instance.
+    #
+    # @param access_token [String] OAuth access token (required)
+    # @param http_client [HttpClient, nil] custom HTTP transport; defaults to a new {HttpClient}
+    # @param request_options [RequestOptions, nil] custom request config; defaults to a new {RequestOptions}
+    # @raise [TypeError] if any parameter is not the expected type
     def initialize(access_token, http_client: nil, request_options: nil)
       self.access_token = access_token
       self.http_client = http_client.nil? ? HttpClient.new : http_client
       self.request_options = request_options.nil? ? RequestOptions.new(access_token: access_token) : request_options
     end
 
+    # @return [AdvancedPayment] resource for split-payment operations (marketplace)
     def advanced_payment
       AdvancedPayment.new(request_options, http_client)
     end
 
+    # @return [Card] resource for managing stored cards linked to a customer
     def card
       Card.new(request_options, http_client)
     end
 
+    # @return [CardToken] resource for tokenising card data server-side
     def card_token
       CardToken.new(request_options, http_client)
     end
 
+    # @return [Customer] resource for managing customer records
     def customer
       Customer.new(request_options, http_client)
     end
 
+    # @return [DisbursementRefund] resource for refunding advanced-payment disbursements
     def disbursement_refund
       DisbursementRefund.new(request_options, http_client)
     end
 
+    # @return [User] resource for retrieving the authenticated user's profile
     def user
       User.new(request_options, http_client)
     end
 
+    # @return [IdentificationType] resource for listing supported ID document types
     def identification_type
       IdentificationType.new(request_options, http_client)
     end
 
+    # @return [MerchantOrder] resource for grouping payments into merchant orders
     def merchant_order
       MerchantOrder.new(request_options, http_client)
     end
 
+    # @return [Payment] resource for creating, searching, and managing payments
     def payment
       Payment.new(request_options, http_client)
     end
 
+    # @return [PaymentMethods] resource for listing available payment methods
     def payment_methods
       PaymentMethods.new(request_options, http_client)
     end
 
+    # @return [Preference] resource for Checkout Pro payment preferences
     def preference
       Preference.new(request_options, http_client)
     end
 
+    # @return [Refund] resource for issuing full or partial refunds on payments
     def refund
       Refund.new(request_options, http_client)
     end
 
+    # @return [Preapproval] resource for managing recurring subscriptions
     def preapproval
       Preapproval.new(request_options, http_client)
     end
 
+    # @return [PreapprovalPlan] resource for managing subscription plan templates
     def preapproval_plan
       PreapprovalPlan.new(request_options, http_client)
     end
 
+    # @return [Order] resource for creating and managing orders (Checkout API)
     def order
       Order.new(request_options, http_client)
     end
 
+    # @return [OrderTransaction] resource for managing transactions within an order
     def order_transaction
       OrderTransaction.new(request_options, http_client)
     end
 
-
+    # @param value [String] OAuth access token
+    # @raise [TypeError] if value is not a String
     def access_token=(value)
       raise TypeError, 'Param access_token must be a String' unless value.is_a?(String)
 
       @access_token = value
     end
 
+    # @param value [HttpClient] HTTP transport implementation
+    # @raise [TypeError] if value is not an {HttpClient} instance
     def http_client=(value)
       raise TypeError, 'Param http_client must be a implementation of HttpClient' unless value.is_a?(HttpClient)
 
       @http_client = value
     end
 
+    # @param value [RequestOptions] request configuration object
+    # @raise [TypeError] if value is not a {RequestOptions} instance
     def request_options=(value)
       raise TypeError, 'Param request_options must be a RequestOptions object' unless value.is_a?(RequestOptions)
 
       @request_options = value
     end
 
+    # Returns the current request options, ensuring the access token is set.
+    #
+    # If the stored request options have a nil access token, the SDK's
+    # access token is injected automatically.
+    #
+    # @return [RequestOptions] current request configuration
     def request_options
       @request_options.access_token = @access_token if @request_options.access_token.nil?
       @request_options


### PR DESCRIPTION
## Summary
Adds YARD-style comments to the public SDK surface (resources, requests, responses) and links to the MercadoPago API reference on client methods to improve IDE autocomplete and developer experience.

## Changes
- 22 files updated with inline YARD comments
- Public classes and methods annotated with descriptions and parameter docs
- Links to the official MercadoPago API reference added to client methods

## Test plan
- [ ] CI green