### PR TITLE
Migrate HTTP client from rest-client to faraday

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mercadopago-sdk (2.4.1)
+    mercadopago-sdk (3.0.0)
       faraday (~> 2.0)
       json (~> 2.5)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,32 +2,35 @@ PATH
   remote: .
   specs:
     mercadopago-sdk (2.4.1)
+      faraday (~> 2.0)
       json (~> 2.5)
-      rest-client (~> 2.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
     coderay (1.1.3)
-    domain_name (0.6.20240107)
-    http-accept (1.7.0)
-    http-cookie (1.0.8)
-      domain_name (~> 0.5)
+    drb (2.2.3)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     json (2.9.1)
     language_server-protocol (3.17.0.3)
-    logger (1.6.5)
+    logger (1.7.0)
     method_source (1.0.0)
-    mime-types (3.6.0)
-      logger
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0107)
-    minitest (5.14.4)
-    netrc (0.11.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
+    prism (1.9.0)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -35,11 +38,6 @@ GEM
     rainbow (3.1.1)
     rake (13.0.3)
     regexp_parser (2.10.0)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rubocop (1.70.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -53,9 +51,10 @@ GEM
     rubocop-ast (1.37.0)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
-    unicode-display_width (3.1.4)
-      unicode-emoji (~> 4.0, >= 4.0.4)
-    unicode-emoji (4.0.4)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    uri (1.1.1)
 
 PLATFORMS
   ruby
@@ -68,4 +67,4 @@ DEPENDENCIES
   rubocop (~> 1.70)
 
 BUNDLED WITH
-   2.2.22
+   2.5.23

--- a/lib/mercadopago/config/config.rb
+++ b/lib/mercadopago/config/config.rb
@@ -9,7 +9,7 @@ module Mercadopago
   # there is no need to instantiate this class directly.
   class Config
     # Current SDK version following SemVer.
-    @@VERSION = '2.4.1'
+    @@VERSION = '3.0.0'
 
     # User-Agent string sent with every HTTP request for server-side tracking.
     @@USER_AGENT = "MercadoPago Ruby SDK v#{@@VERSION}"
@@ -29,7 +29,7 @@ module Mercadopago
     # MIME type used for form-encoded request bodies.
     @@MIME_FORM = 'application/x-www-form-urlencoded'
 
-    # @return [String] current SDK version (e.g. "2.4.1")
+    # @return [String] current SDK version (e.g. "3.0.0")
     def version
       @@VERSION
     end

--- a/lib/mercadopago/http/http_client.rb
+++ b/lib/mercadopago/http/http_client.rb
@@ -1,74 +1,61 @@
 # typed: false
 # frozen_string_literal: true
 
-require 'rest-client'
+require 'faraday'
 require 'json'
 
 module Mercadopago
   class HttpClient
+    RETRYABLE_STATUSES = [429, 500, 502, 503, 504].freeze
+
     def get(url:, headers:, params: nil, timeout: nil, maxretries: nil)
       try = 0
-      headers = {} if headers.nil?
-      headers[:params] = params unless params.nil?
+      max = maxretries.to_i
 
-      begin
-        result = RestClient::Request.execute(method: :get, url: url, headers: headers, timeout: timeout)
-        {
-          status: result.code,
-          response: JSON.parse(result.body)
-        }
-      rescue RestClient::Exception => e
+      loop do
+        response = execute(:get, url, headers: headers, params: params, timeout: timeout)
+        return build_result(response) unless RETRYABLE_STATUSES.include?(response.status) && try < max - 1
+
         try += 1
-        if [429, 500, 502, 503, 504].include?(e.http_code) && (try < maxretries)
-          sleep(1)
-          retry
-        end
-        {
-          status: e.http_code,
-          response: JSON.parse(e.response.body)
-        }
+        sleep(1)
       end
     end
 
     def post(url:, data:, headers:, timeout: nil)
-      result = RestClient::Request.execute(method: :post, url: url, payload: data, headers: headers,
-                                           timeout: timeout)
-      {
-        status: result.code,
-        response: JSON.parse(result.body)
-      }
-    rescue RestClient::Exception => e
-      {
-        status: e.http_code,
-        response: JSON.parse(e.response.body)
-      }
+      build_result(execute(:post, url, headers: headers, body: data, timeout: timeout))
     end
 
     def put(url:, data:, headers:, timeout: nil)
-      result = RestClient::Request.execute(method: :put, url: url, payload: data, headers: headers,
-                                           timeout: timeout)
-      {
-        status: result.code,
-        response: JSON.parse(result.body)
-      }
-    rescue RestClient::Exception => e
-      {
-        status: e.http_code,
-        response: JSON.parse(e.response.body)
-      }
+      build_result(execute(:put, url, headers: headers, body: data, timeout: timeout))
     end
 
     def delete(url:, headers:, timeout: nil)
-      result = RestClient::Request.execute(method: 'delete', url: url, headers: headers, timeout: timeout)
-      {
-        status: result.code,
-        response: result.body.is_a?(String) && !result.body.strip.empty? ? JSON.parse(result.body) : nil
-      }
-    rescue RestClient::Exception => e
-      {
-        status: e.http_code,
-        response: JSON.parse(e.response.body)
-      }
+      build_result(execute(:delete, url, headers: headers, timeout: timeout), allow_empty: true)
+    end
+
+    private
+
+    def execute(method, url, headers:, params: nil, body: nil, timeout: nil)
+      conn = Faraday.new(request: timeout ? { timeout: timeout } : {})
+      conn.public_send(method, url) do |req|
+        req.headers.update(stringify_keys(headers)) if headers && !headers.empty?
+        req.params.update(params) if params
+        req.body = body if body
+      end
+    end
+
+    def build_result(response, allow_empty: false)
+      body = response.body
+      parsed = if allow_empty && (body.nil? || body.to_s.strip.empty?)
+                 nil
+               else
+                 JSON.parse(body)
+               end
+      { status: response.status, response: parsed }
+    end
+
+    def stringify_keys(headers)
+      headers.transform_keys(&:to_s)
     end
   end
 end

--- a/mercadopago.gemspec
+++ b/mercadopago.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name                  = 'mercadopago-sdk'
-  gem.version               = '2.4.1'
+  gem.version               = '3.0.0'
   gem.required_ruby_version = '>= 3.1.6'
   gem.author                = 'Mercado Pago'
   gem.description           = 'Mercado Pago Ruby SDK'

--- a/mercadopago.gemspec
+++ b/mercadopago.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(tests)/})
   gem.require_paths = ['lib']
 
+  gem.add_dependency 'faraday', '~>2.0'
   gem.add_dependency 'json', '~>2.5'
-  gem.add_dependency 'rest-client', '~>2.1'
   gem.add_development_dependency 'pry', '~>0.14'
   gem.add_development_dependency 'rake', '~>13.0'
 end


### PR DESCRIPTION
## Summary
Replaces the unmaintained `rest-client` gem with `faraday` to remediate dependency risk and modernize the HTTP layer.

## Changes
- `lib/mercadopago/http/http_client.rb`: rewrite HTTP layer on top of `faraday` **(breaking — `rest-client` removed)**
- `mercadopago.gemspec`: swap runtime dependency
- `Gemfile.lock`: regenerated against the new dependency tree

## Test plan
- [ ] CI green