### PR TITLE
chore: add Dependabot version updates and dependency audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,6 @@ updates:
       time: "09:00"
       timezone: "America/Bogota"
     open-pull-requests-limit: 5
-    reviewers:
-      - "mercadopago/backend-sdks"
     assignees:
       - "mercadopago/backend-sdks"
     labels:
@@ -37,8 +35,6 @@ updates:
       time: "09:00"
       timezone: "America/Bogota"
     open-pull-requests-limit: 1
-    reviewers:
-      - "mercadopago/backend-sdks"
     labels:
       - "dependencies"
       - "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+# Dependabot version updates — sdk-ruby
+# Ubicación obligatoria: .github/dependabot.yml
+# Ecosistemas: bundler (Ruby) + github-actions
+version: 2
+
+updates:
+  # ── Ruby / Bundler ───────────────────────────────────────────────────
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Bogota"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "mercadopago/backend-sdks"
+    assignees:
+      - "mercadopago/backend-sdks"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    # bundler puede ejecutar código de gemspec durante el update — lo bloqueamos
+    insecure-external-code-execution: "deny"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # ── GitHub Actions (CI) ──────────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Bogota"
+    open-pull-requests-limit: 1
+    reviewers:
+      - "mercadopago/backend-sdks"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,9 @@ jobs:
       run: bundle exec rake
       env:
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN_V2 }}
+
+    - name: Install bundler-audit
+      run: gem install bundler-audit
+
+    - name: Dependency audit
+      run: bundle-audit check --update


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` to enable proactive dependency updates (Bundler + GitHub Actions), weekly on Mondays at 09:00 America/Bogota, assigned to `mercadopago/backend-sdks`, ignoring semver-major bumps. Includes `insecure-external-code-execution: deny` to block gemspec code execution during updates
- Add dependency audit step to CI (`bundle-audit check --update`) to close the Dependabot loop: PR opened → CI runs → audit confirms CVE resolved → merge

## Test plan

- [ ] Verify `.github/dependabot.yml` is valid (GitHub will show a check in Security → Dependabot after merge)
- [ ] Enable **Dependabot version updates** in Settings → Security & analysis
- [ ] Confirm CI audit step runs on next PR