### PR TITLE
feat(order): document AP fields in Order class (IXE-679)

### DIFF
--- a/lib/mercadopago/resources/order.rb
+++ b/lib/mercadopago/resources/order.rb
@@ -9,6 +9,52 @@ module Mercadopago
   # Use {OrderTransaction} to manage individual transactions within
   # an order.
   #
+  # == Automatic Payments (AP) — supported Hash keys for +stored_credential+
+  #
+  #   {
+  #     payment_initiator:    String,   # "cardholder" | "merchant"
+  #     reason:               String,   # "recurring" | "installment" | "unscheduled"
+  #     store_payment_method: Boolean,
+  #     first_payment:        Boolean,
+  #     prev_transaction_ref: String    # ID of the previous transaction in the series.
+  #                                     # Required from the second charge onwards.
+  #   }
+  #
+  # == Supported Hash keys for +automatic_payments+
+  #
+  #   {
+  #     payment_profile_id: String,   # Stored payment profile ID.
+  #     retries:            Integer,  # Max retry attempts on failure.
+  #     schedule_date:      String,   # ISO 8601 scheduled charge date.
+  #     due_date:           String    # ISO 8601 payment due date.
+  #   }
+  #
+  # == Supported Hash keys for +subscription_data+
+  #
+  #   {
+  #     invoice_id:   String,  # ID of the invoice being paid.
+  #     billing_date: String,  # ISO 8601 billing date.
+  #     subscription_sequence: {
+  #       number: Integer,     # Current payment number (1-based).
+  #       total:  Integer      # Total payments in the plan.
+  #     },
+  #     invoice_period: {
+  #       type:   String,      # "monthly" | "daily" | "yearly".
+  #       period: Integer      # Number of period units.
+  #     }
+  #   }
+  #
+  # == Supported Hash keys for +integration_data+ (root of order request)
+  #
+  #   {
+  #     integrator_id:  String,  # Certified integrator ID.
+  #     platform_id:    String,  # Platform ID assigned by MercadoPago.
+  #     corporation_id: String,  # Corporation ID for multi-account setups.
+  #     sponsor: {
+  #       id: String             # MercadoPago user ID of the sponsor.
+  #     }
+  #   }
+  #
   # @see https://www.mercadopago.com/developers/en/docs/checkout-api/landing
   class Order < MPBase
     # Creates a new order.


### PR DESCRIPTION
## Summary

- **`lib/mercadopago/resources/order.rb`** → added YARD documentation to the `Order` class listing all supported Hash keys for the Automatic Payments flow with types and descriptions.

Documented fields:
- `stored_credential`: `payment_initiator`, `reason`, `store_payment_method`, `first_payment`, **`prev_transaction_ref`** (String — required from the second recurring charge onwards).
- `automatic_payments`: `payment_profile_id`, `retries`, `schedule_date`, `due_date`.
- `subscription_data`: full billing cycle structure including `subscription_sequence` and `invoice_period`.
- `integration_data`: `integrator_id`, `platform_id`, `corporation_id`, `sponsor.id`.

## Notes

Ruby uses plain Hashes for requests — all AP fields already work today without code changes. This PR makes them discoverable in the source so developers don't need to consult external references to know which keys are supported.

## Context

Part of IXE-679: fields required for the Automatic Payments (recurring without CVV) flow in the Orders API were missing or undocumented in the public SDKs. Companion PRs exist for Java, Go, .NET, Node.js, PHP and Python.

## Test plan

- [x] `ruby -c lib/mercadopago/resources/order.rb` — Syntax OK
- [ ] Integration tests (not run per policy — require ACCESS_TOKEN)

Generated with [Claude Code](https://claude.com/claude-code)