### PR TITLE
fix(webhook): preserve data.id case in signature manifest

### DIFF
--- a/lib/mercadopago/webhook/validator.rb
+++ b/lib/mercadopago/webhook/validator.rb
@@ -157,7 +157,7 @@ module Mercadopago
       # Builds the HMAC manifest, omitting empty pairs per the documented rule.
       def self.build_manifest(data_id, request_id, timestamp)
         parts = []
-        parts << "id:#{data_id.downcase}" unless data_id.nil?
+        parts << "id:#{data_id}" unless data_id.nil?
         parts << "request-id:#{request_id}" unless request_id.nil?
         parts << "ts:#{timestamp}"
         "#{parts.join(';')};"

--- a/tests/test_webhook_signature_validator.rb
+++ b/tests/test_webhook_signature_validator.rb
@@ -19,7 +19,7 @@ class TestWebhookSignatureValidator < Minitest::Test
 
   def compute_hash(data_id, request_id, ts, secret)
     parts = []
-    parts << "id:#{data_id.downcase}" if data_id && !data_id.empty?
+    parts << "id:#{data_id}" if data_id && !data_id.empty?
     parts << "request-id:#{request_id}" if request_id && !request_id.empty?
     parts << "ts:#{ts}"
     manifest = "#{parts.join(';')};"
@@ -40,8 +40,9 @@ class TestWebhookSignatureValidator < Minitest::Test
   end
 
   # case 2
-  def test_uppercase_dataid_is_lowercased
-    Validator.validate(build_header(valid_hash), REQUEST_ID, DATA_ID_RAW, SECRET)
+  def test_uppercase_dataid_is_preserved
+    upper_hash = compute_hash(DATA_ID_RAW, REQUEST_ID, TS, SECRET)
+    Validator.validate(build_header(upper_hash), REQUEST_ID, DATA_ID_RAW, SECRET)
   end
 
   # case 3


### PR DESCRIPTION
## Problem

`WebhookSignatureValidator.validate` was calling `.downcase` on `data_id` before building the HMAC manifest. MercadoPago signs webhook notifications using the original casing of `data.id`, so any notification with uppercase or mixed-case identifiers would fail validation with `SignatureMismatch`.

## Fix

Remove the `.downcase` call in `build_manifest` so the value is included exactly as received.

## Testing

Verified manually with `data.id` values in uppercase (`ORDER123`), lowercase (`order123`), and mixed case (`oRdEr`) — all pass when the signature was generated with the same casing.