### PR TITLE
Add industry fields to examples and tests

### DIFF
--- a/examples/preference/create_with_industry_fields.rb
+++ b/examples/preference/create_with_industry_fields.rb
@@ -1,20 +1,17 @@
-require_relative '../../lib/mercadopago'
+# Example: Create a Checkout Preference with industry-specific fields.
+# Demonstrates payer authentication info, item category descriptors,
+# passenger/route details, and shipment address enrichment.
 
+require_relative '../../lib/mercadopago'
 
 sdk = Mercadopago::SDK.new('<ACCESS_TOKEN>')
 
-def create_checkout_pro_order(sdk)
+def create_preference_with_industry_fields(sdk)
   request = {
-    total_amount: '500.00',
-    external_reference: 'ext_ref_checkout_pro',
-    capture_mode: 'automatic',
-    marketplace_fee: '5.00',
-    description: 'Travel package SAO-RIO with insurance',
-    expiration_time: 'P1D',
     payer: {
+      name: 'John',
+      surname: 'Smith',
       email: '<PAYER_EMAIL>',
-      first_name: 'John',
-      last_name: 'Smith',
       phone: {
         area_code: '11',
         number: '999998888'
@@ -23,6 +20,11 @@ def create_checkout_pro_order(sdk)
         type: 'CPF',
         number: '12345678909'
       },
+      address: {
+        zip_code: '01310-100',
+        street_name: 'Av. Paulista',
+        street_number: 1000
+      },
       date_created: '2024-01-01T00:00:00Z',
       authentication_type: 'Gmail',
       is_prime_user: false,
@@ -30,72 +32,16 @@ def create_checkout_pro_order(sdk)
       last_purchase: '2024-01-01T00:00:00Z',
       registration_date: '2023-01-01T00:00:00Z'
     },
-    shipment: {
-      mode: 'custom',
-      local_pickup: false,
-      express_shipment: false,
-      cost: '15.00',
-      free_shipping: false,
-      address: {
-        zip_code: '01310-100',
-        street_name: 'Av. Paulista',
-        street_number: '1000',
-        neighborhood: 'Bela Vista',
-        city: 'Sao Paulo',
-        state_name: 'Sao Paulo',
-        city_name: 'Sao Paulo',
-        floor: '2',
-        apartment: 'A'
-      }
-    },
-    config: {
-      statement_descriptor: 'MYSTORE',
-      default_payment_due_date: 'P1D',
-      online: {
-        available_from: '2026-01-01T00:00:00Z',
-        allowed_user_type: 'account_only',
-        success_url: 'https://example.com/success',
-        failure_url: 'https://example.com/failure',
-        pending_url: 'https://example.com/pending',
-        auto_return: 'approved',
-        tracks: [
-          {
-            type: 'google_ad',
-            values: {
-              conversion_id: '21312312312123',
-              conversion_label: 'TEST'
-            }
-          },
-          {
-            type: 'facebook_ad',
-            values: {
-              pixel_id: '21312312312123'
-            }
-          }
-        ]
-      },
-      payment_method: {
-        max_installments: 12,
-        not_allowed_ids: ['amex'],
-        not_allowed_types: ['ticket'],
-        installments: {
-          interest_free: {
-            type: 'range',
-            values: [2, 6]
-          }
-        }
-      }
-    },
     items: [
       {
-        external_code: 'ITEM-001',
+        id: 'ITEM-001',
         title: 'Flight SAO-RIO',
         description: 'Round trip, economy class',
         category_id: 'travels',
         picture_url: 'https://example.com/img.jpg',
         quantity: 1,
-        unit_price: '450.00',
-        type: 'travel',
+        currency_id: 'BRL',
+        unit_price: 450.00,
         warranty: false,
         event_date: '2027-01-15T00:00:00.000-03:00',
         category_descriptor: {
@@ -117,14 +63,14 @@ def create_checkout_pro_order(sdk)
         }
       },
       {
-        external_code: 'ITEM-002',
+        id: 'ITEM-002',
         title: 'Travel insurance',
         description: 'Basic coverage during trip',
         category_id: 'travels',
         picture_url: 'https://example.com/insurance.jpg',
         quantity: 1,
-        unit_price: '50.00',
-        type: 'travel',
+        currency_id: 'BRL',
+        unit_price: 50.00,
         warranty: true,
         event_date: '2027-01-15T00:00:00.000-03:00',
         category_descriptor: {
@@ -145,7 +91,32 @@ def create_checkout_pro_order(sdk)
           }
         }
       }
-    ]
+    ],
+    shipments: {
+      mode: 'custom',
+      local_pickup: false,
+      express_shipment: false,
+      cost: 15.0,
+      free_shipping: false,
+      receiver_address: {
+        zip_code: '01310-100',
+        street_name: 'Av. Paulista',
+        street_number: 1000,
+        state_name: 'Sao Paulo',
+        city_name: 'Sao Paulo',
+        floor: '2',
+        apartment: 'A'
+      }
+    },
+    back_urls: {
+      success: 'https://example.com/success',
+      failure: 'https://example.com/failure',
+      pending: 'https://example.com/pending'
+    },
+    auto_return: 'approved',
+    external_reference: 'MP0001',
+    notification_url: 'https://example.com/notifications',
+    statement_descriptor: 'MYSTORE'
   }
 
   custom_headers = {
@@ -153,15 +124,14 @@ def create_checkout_pro_order(sdk)
   }
   custom_request_options = Mercadopago::RequestOptions.new(custom_headers: custom_headers)
 
-  result = sdk.order.create_checkout_pro(request, request_options: custom_request_options)
-  order = result[:response]
+  result = sdk.preference.create(request, request_options: custom_request_options)
+  preference = result[:response]
 
-  puts "Order id: #{order['id']}"
-  puts "Status: #{order['status']}"
-  puts "Redirect buyer to Checkout Pro: #{order['checkout_url']}"
+  puts "Preference id: #{preference['id']}"
+  puts "Init point: #{preference['init_point']}"
 
 rescue StandardError => e
   puts e.message
 end
 
-create_checkout_pro_order(sdk)
+create_preference_with_industry_fields(sdk)

--- a/tests/test_payment.rb
+++ b/tests/test_payment.rb
@@ -60,15 +60,27 @@ class TestPayment < Minitest::Test
           phone: {
             area_code: '011',
             number: '987654321'
+          },
+          authentication_type: 'WEB',
+          is_prime_user: false,
+          is_first_purchase_online: false,
+          last_purchase: '2024-01-01T00:00:00Z',
+          identification: {
+            type: 'CPF',
+            number: '19119119100'
           }
         },
         shipments: {
+          express_shipment: false,
+          local_pickup: false,
           receiver_address: {
             street_name: 'Av das Nacoes Unidas',
             street_number: 3003,
             zip_code: '06233200',
             city_name: 'Buzios',
-            state_name: 'Rio de Janeiro'
+            state_name: 'Rio de Janeiro',
+            floor: '3',
+            apartment: 'B'
           }
         }
       }
@@ -136,15 +148,27 @@ class TestPayment < Minitest::Test
           phone: {
             area_code: '011',
             number: '987654321'
+          },
+          authentication_type: 'WEB',
+          is_prime_user: false,
+          is_first_purchase_online: false,
+          last_purchase: '2024-01-01T00:00:00Z',
+          identification: {
+            type: 'CPF',
+            number: '19119119100'
           }
         },
         shipments: {
+          express_shipment: false,
+          local_pickup: false,
           receiver_address: {
             street_name: 'Av das Nacoes Unidas',
             street_number: 3003,
             zip_code: '06233200',
             city_name: 'Buzios',
-            state_name: 'Rio de Janeiro'
+            state_name: 'Rio de Janeiro',
+            floor: '3',
+            apartment: 'B'
           }
         }
       }
@@ -208,15 +232,27 @@ class TestPayment < Minitest::Test
           phone: {
             area_code: '011',
             number: '987654321'
+          },
+          authentication_type: 'WEB',
+          is_prime_user: false,
+          is_first_purchase_online: false,
+          last_purchase: '2024-01-01T00:00:00Z',
+          identification: {
+            type: 'CPF',
+            number: '19119119100'
           }
         },
         shipments: {
+          express_shipment: false,
+          local_pickup: false,
           receiver_address: {
             street_name: 'Av das Nacoes Unidas',
             street_number: 3003,
             zip_code: '06233200',
             city_name: 'Buzios',
-            state_name: 'Rio de Janeiro'
+            state_name: 'Rio de Janeiro',
+            floor: '3',
+            apartment: 'B'
           }
         }
       }


### PR DESCRIPTION
Update create_checkout_pro.rb example and test_payment.rb with full industry data fields: payer date_created, authentication_type, is_prime_user, is_first_purchase_online, last_purchase, registration_date; item warranty, category_descriptor with passenger and route; shipment express_shipment, state_name, city_name, floor, apartment.

Add new example preference/create_with_industry_fields.rb demonstrating all industry fields for the Checkout Pro preferences API.