### PR TITLE
fix: escape dynamic API path parameters

### DIFF
--- a/lib/mercadopago/core/mp_base.rb
+++ b/lib/mercadopago/core/mp_base.rb
@@ -1,6 +1,8 @@
 # typed: false
 # frozen_string_literal: true
 
+require 'cgi'
+
 module Mercadopago
   # Abstract base class for every API resource (Payment, Customer, Order, etc.).
   #
@@ -59,6 +61,11 @@ module Mercadopago
       headers.merge!(extra_headers) unless extra_headers.nil?
 
       headers
+    end
+
+    # Encodes a dynamic URL path segment before interpolation.
+    def _path_param(value)
+      CGI.escape(value.to_s).gsub('+', '%20')
     end
 
     # Performs a GET request against the MercadoPago API.

--- a/lib/mercadopago/resources/advanced_payment.rb
+++ b/lib/mercadopago/resources/advanced_payment.rb
@@ -29,7 +29,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with payment details
     def get(advanced_payment_id, request_options: nil)
-      _get(uri: "/v1/advanced_payments/#{advanced_payment_id}", request_options: request_options)
+      _get(uri: "/v1/advanced_payments/#{_path_param(advanced_payment_id)}", request_options: request_options)
     end
 
     # Creates a new advanced payment with split disbursements.
@@ -54,7 +54,7 @@ module Mercadopago
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the captured payment
     def capture(advanced_payment_id, request_options: nil)
       capture_data = { capture: true }
-      _put(uri: "/v1/advanced_payments/#{advanced_payment_id}", data: capture_data, request_options: request_options)
+      _put(uri: "/v1/advanced_payments/#{_path_param(advanced_payment_id)}", data: capture_data, request_options: request_options)
     end
 
     # Updates an existing advanced payment.
@@ -67,7 +67,7 @@ module Mercadopago
     def update(advanced_payment_id, advanced_payment_data, request_options: nil)
       raise TypeError, 'Param advanced_payment_data must be a Hash' unless advanced_payment_data.is_a?(Hash)
 
-      _put(uri: "/v1/advanced_payments/#{advanced_payment_id}", data: advanced_payment_data,
+      _put(uri: "/v1/advanced_payments/#{_path_param(advanced_payment_id)}", data: advanced_payment_data,
            request_options: request_options)
     end
 
@@ -78,7 +78,7 @@ module Mercadopago
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the cancelled payment
     def cancel(advanced_payment_id, request_options: nil)
       cancel_data = { status: 'cancelled' }
-      _put(uri: "/v1/advanced_payments/#{advanced_payment_id}", data: cancel_data, request_options: request_options)
+      _put(uri: "/v1/advanced_payments/#{_path_param(advanced_payment_id)}", data: cancel_data, request_options: request_options)
     end
 
     # Changes the money release date for an advanced payment's disbursements.
@@ -89,7 +89,7 @@ module Mercadopago
     # @return [Hash{Symbol => Object}] +:status+ and +:response+
     def update_release_date(advanced_payment_id, release_date, request_options: nil)
       disbursement_data = { money_release_date: release_date.strftime('%Y-%m-%d %H:%M:%S.%f') }
-      _post(uri: "/v1/advanced_payments/#{advanced_payment_id}/disburses", data: disbursement_data,
+      _post(uri: "/v1/advanced_payments/#{_path_param(advanced_payment_id)}/disburses", data: disbursement_data,
             request_options: request_options)
     end
   end

--- a/lib/mercadopago/resources/card.rb
+++ b/lib/mercadopago/resources/card.rb
@@ -18,7 +18,7 @@ module Mercadopago
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with card details
     # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/cards/get-card/get
     def get(customer_id, card_id, request_options: nil)
-      _get(uri: "/v1/customers/#{customer_id}/cards/#{card_id}", request_options: request_options)
+      _get(uri: "/v1/customers/#{_path_param(customer_id)}/cards/#{_path_param(card_id)}", request_options: request_options)
     end
 
     # Saves a new card for a customer using a previously generated card token.
@@ -32,7 +32,7 @@ module Mercadopago
     def create(customer_id, card_data, request_options: nil)
       raise TypeError, 'Param card_data must be a Hash' if card_data.nil? || !card_data.is_a?(Hash)
 
-      _post(uri: "/v1/customers/#{customer_id}/cards/", data: card_data, request_options: request_options)
+      _post(uri: "/v1/customers/#{_path_param(customer_id)}/cards/", data: card_data, request_options: request_options)
     end
 
     # Deletes a saved card from a customer.
@@ -43,7 +43,7 @@ module Mercadopago
     # @return [Hash{Symbol => Object}] +:status+ and +:response+
     # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/cards/delete-card/delete
     def delete(customer_id, card_id, request_options: nil)
-      _delete(uri: "/v1/customers/#{customer_id}/cards/#{card_id}", request_options: request_options)
+      _delete(uri: "/v1/customers/#{_path_param(customer_id)}/cards/#{_path_param(card_id)}", request_options: request_options)
     end
 
     # Lists all saved cards for a customer.
@@ -53,7 +53,7 @@ module Mercadopago
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with an array of cards
     # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/cards/get-customer-cards/get
     def list(customer_id, request_options: nil)
-      _get(uri: "/v1/customers/#{customer_id}/cards", request_options: request_options)
+      _get(uri: "/v1/customers/#{_path_param(customer_id)}/cards", request_options: request_options)
     end
   end
 end

--- a/lib/mercadopago/resources/card_token.rb
+++ b/lib/mercadopago/resources/card_token.rb
@@ -16,7 +16,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with token details
     def get(card_token_id, request_options: nil)
-      _get(uri: "/v1/card_tokens/#{card_token_id}", request_options: request_options)
+      _get(uri: "/v1/card_tokens/#{_path_param(card_token_id)}", request_options: request_options)
     end
 
     # Creates a new card token from raw card data.

--- a/lib/mercadopago/resources/chargeback.rb
+++ b/lib/mercadopago/resources/chargeback.rb
@@ -17,7 +17,7 @@ module Mercadopago
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the full chargeback object
     # @see https://www.mercadopago.com.br/developers/en/reference/chargebacks/
     def get(chargeback_id, request_options: nil)
-      _get(uri: "/v1/chargebacks/#{chargeback_id}", request_options: request_options)
+      _get(uri: "/v1/chargebacks/#{_path_param(chargeback_id)}", request_options: request_options)
     end
 
     # Searches chargebacks matching the given filters.

--- a/lib/mercadopago/resources/customer.rb
+++ b/lib/mercadopago/resources/customer.rb
@@ -26,7 +26,7 @@ module Mercadopago
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with customer details
     # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/customers/get-customer/get
     def get(customer_id, request_options: nil)
-      _get(uri: "/v1/customers/#{customer_id}", request_options: request_options)
+      _get(uri: "/v1/customers/#{_path_param(customer_id)}", request_options: request_options)
     end
 
     # Creates a new customer.
@@ -53,7 +53,7 @@ module Mercadopago
     def update(customer_id, customer_data, request_options: nil)
       raise TypeError, 'Param customer_data must be a Hash' unless customer_data.is_a?(Hash)
 
-      _put(uri: "/v1/customers/#{customer_id}", data: customer_data, request_options: request_options)
+      _put(uri: "/v1/customers/#{_path_param(customer_id)}", data: customer_data, request_options: request_options)
     end
 
     # Deletes a customer permanently.
@@ -62,7 +62,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+
     def delete(customer_id, request_options: nil)
-      _delete(uri: "/v1/customers/#{customer_id}", request_options: request_options)
+      _delete(uri: "/v1/customers/#{_path_param(customer_id)}", request_options: request_options)
     end
   end
 end

--- a/lib/mercadopago/resources/disbursement_refund.rb
+++ b/lib/mercadopago/resources/disbursement_refund.rb
@@ -14,7 +14,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with an array of refunds
     def list(advanced_payment_id, request_options: nil)
-      _get(uri: "/v1/advanced_payments/#{advanced_payment_id}/refunds", request_options: nil)
+      _get(uri: "/v1/advanced_payments/#{_path_param(advanced_payment_id)}/refunds", request_options: nil)
     end
 
     # Refunds all disbursements of an advanced payment at once.
@@ -23,7 +23,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with refund details
     def create_all(advanced_payment_id, request_options: nil)
-      _post(uri: "/v1/advanced_payments/#{advanced_payment_id}/refunds", request_options: request_options)
+      _post(uri: "/v1/advanced_payments/#{_path_param(advanced_payment_id)}/refunds", request_options: request_options)
     end
 
     # Refunds a single disbursement (full or partial).
@@ -39,7 +39,7 @@ module Mercadopago
     def create(advanced_payment_id, disbursement_id, amount: nil, request_options: nil)
       disbursement_refund_data = amount.nil? ? nil : { amount: amount }
 
-      _post(uri: "/v1/advanced_payments/#{advanced_payment_id}/disbursements/#{disbursement_id}/refunds",
+      _post(uri: "/v1/advanced_payments/#{_path_param(advanced_payment_id)}/disbursements/#{_path_param(disbursement_id)}/refunds",
             data: disbursement_refund_data, request_options: request_options)
     end
   end

--- a/lib/mercadopago/resources/invoice.rb
+++ b/lib/mercadopago/resources/invoice.rb
@@ -19,7 +19,7 @@ module Mercadopago
     #   including +:status+, +:transaction_amount+, +:preapproval_id+, and +:payment+ details
     # @see https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/get-authorized-payment/get
     def get(invoice_id, request_options: nil)
-      _get(uri: "/authorized_payments/#{invoice_id}", request_options: request_options)
+      _get(uri: "/authorized_payments/#{_path_param(invoice_id)}", request_options: request_options)
     end
 
     # Searches invoices matching the given filters.

--- a/lib/mercadopago/resources/merchant_order.rb
+++ b/lib/mercadopago/resources/merchant_order.rb
@@ -30,7 +30,7 @@ module Mercadopago
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with order details
     # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-pro/merchant_orders/get-merchant-order/get
     def get(merchant_order_id, request_options: nil)
-      _get(uri: "/merchant_orders/#{merchant_order_id}", request_options: request_options)
+      _get(uri: "/merchant_orders/#{_path_param(merchant_order_id)}", request_options: request_options)
     end
 
     # Creates a new merchant order.
@@ -57,7 +57,7 @@ module Mercadopago
     def update(merchant_order_id, merchant_order_data, request_options: nil)
       raise TypeError, 'Param merchant_orders_object must be a Hash' unless merchant_order_data.is_a?(Hash)
 
-      _put(uri: "/merchant_orders/#{merchant_order_id}", data: merchant_order_data,
+      _put(uri: "/merchant_orders/#{_path_param(merchant_order_id)}", data: merchant_order_data,
            request_options: request_options)
     end
   end

--- a/lib/mercadopago/resources/order.rb
+++ b/lib/mercadopago/resources/order.rb
@@ -99,7 +99,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with order details
     def get(order_id, request_options: nil)
-      _get(uri: "/v1/orders/#{order_id}", request_options: request_options)
+      _get(uri: "/v1/orders/#{_path_param(order_id)}", request_options: request_options)
     end
 
     # Processes (confirms) an order, triggering payment execution.
@@ -108,7 +108,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the processed order
     def process(order_id, request_options: nil)
-      _post(uri: "/v1/orders/#{order_id}/process", data: nil, request_options: request_options)
+      _post(uri: "/v1/orders/#{_path_param(order_id)}/process", data: nil, request_options: request_options)
     end
 
     # Refunds an order (full or partial).
@@ -124,7 +124,7 @@ module Mercadopago
     def refund(order_id, refund_data: nil, request_options: nil)
       raise TypeError, 'Param refund_data must be a Hash' unless refund_data.nil? || refund_data.is_a?(Hash)
 
-      _post(uri: "/v1/orders/#{order_id}/refund", data: refund_data, request_options: request_options)
+      _post(uri: "/v1/orders/#{_path_param(order_id)}/refund", data: refund_data, request_options: request_options)
     end
 
     # Cancels an order that has not yet been captured.
@@ -133,7 +133,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the cancelled order
     def cancel(order_id, request_options: nil)
-      _post(uri: "/v1/orders/#{order_id}/cancel", data: nil, request_options: request_options)
+      _post(uri: "/v1/orders/#{_path_param(order_id)}/cancel", data: nil, request_options: request_options)
     end
 
     # Captures a previously authorized order.
@@ -142,7 +142,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the captured order
     def capture(order_id, request_options: nil)
-      _post(uri: "/v1/orders/#{order_id}/capture", data: nil, request_options: request_options)
+      _post(uri: "/v1/orders/#{_path_param(order_id)}/capture", data: nil, request_options: request_options)
     end
 
     # Searches orders matching the given filters.

--- a/lib/mercadopago/resources/order_transaction.rb
+++ b/lib/mercadopago/resources/order_transaction.rb
@@ -20,7 +20,7 @@ module Mercadopago
     def create(order_id, order_transaction_data, request_options: nil)
       raise TypeError, 'Param order_transaction_data must be a Hash' unless order_transaction_data.is_a?(Hash)
 
-      _post(uri: "/v1/orders/#{order_id}/transactions", data: order_transaction_data, request_options: request_options)
+      _post(uri: "/v1/orders/#{_path_param(order_id)}/transactions", data: order_transaction_data, request_options: request_options)
     end
 
     # Updates an existing transaction within an order.
@@ -34,7 +34,7 @@ module Mercadopago
     def update(order_id, transaction_id, order_transaction_data, request_options: nil)
       raise TypeError, 'Param order_transaction_data must be a Hash' unless order_transaction_data.is_a?(Hash)
 
-      _put(uri: "/v1/orders/#{order_id}/transactions/#{transaction_id}", data: order_transaction_data, request_options: request_options)
+      _put(uri: "/v1/orders/#{_path_param(order_id)}/transactions/#{_path_param(transaction_id)}", data: order_transaction_data, request_options: request_options)
     end
 
     # Removes a transaction from an order.
@@ -44,7 +44,7 @@ module Mercadopago
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+
     def delete(order_id, transaction_id, request_options: nil)
-      _delete(uri: "/v1/orders/#{order_id}/transactions/#{transaction_id}", request_options: request_options)
+      _delete(uri: "/v1/orders/#{_path_param(order_id)}/transactions/#{_path_param(transaction_id)}", request_options: request_options)
     end
   end
 end

--- a/lib/mercadopago/resources/payment.rb
+++ b/lib/mercadopago/resources/payment.rb
@@ -29,7 +29,7 @@ module Mercadopago
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with payment details
     # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api-payments/get-payment/get
     def get(payment_id, request_options: nil)
-      _get(uri: "/v1/payments/#{payment_id}", request_options: request_options)
+      _get(uri: "/v1/payments/#{_path_param(payment_id)}", request_options: request_options)
     end
 
     # Creates a new payment.
@@ -56,7 +56,7 @@ module Mercadopago
     def update(payment_id, payment_data, request_options: nil)
       raise TypeError, 'Param payment_data must be a Hash' unless payment_data.is_a?(Hash)
 
-      _put(uri: "/v1/payments/#{payment_id}", data: payment_data, request_options: request_options)
+      _put(uri: "/v1/payments/#{_path_param(payment_id)}", data: payment_data, request_options: request_options)
     end
   end
 end

--- a/lib/mercadopago/resources/point.rb
+++ b/lib/mercadopago/resources/point.rb
@@ -43,7 +43,7 @@ module Mercadopago
       raise TypeError, 'Param payment_intent_data must be a Hash' unless payment_intent_data.is_a?(Hash)
 
       _post(
-        uri: "/point/integration-api/devices/#{device_id}/payment-intents",
+        uri: "/point/integration-api/devices/#{_path_param(device_id)}/payment-intents",
         data: payment_intent_data,
         request_options: request_options
       )
@@ -61,7 +61,7 @@ module Mercadopago
     # @see https://www.mercadopago.com/developers/en/reference/in-person-payments/point/orders/get-order/get
     def get(payment_intent_id, request_options: nil)
       _get(
-        uri: "/point/integration-api/payment-intents/#{payment_intent_id}",
+        uri: "/point/integration-api/payment-intents/#{_path_param(payment_intent_id)}",
         request_options: request_options
       )
     end
@@ -78,7 +78,7 @@ module Mercadopago
     # @see https://www.mercadopago.com/developers/en/reference/in-person-payments/point/orders/cancel-order/post
     def cancel(device_id, payment_intent_id, request_options: nil)
       _delete(
-        uri: "/point/integration-api/devices/#{device_id}/payment-intents/#{payment_intent_id}",
+        uri: "/point/integration-api/devices/#{_path_param(device_id)}/payment-intents/#{_path_param(payment_intent_id)}",
         request_options: request_options
       )
     end

--- a/lib/mercadopago/resources/preapproval.rb
+++ b/lib/mercadopago/resources/preapproval.rb
@@ -31,7 +31,7 @@ module Mercadopago
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with subscription details
     # @see https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/get-preapproval/get
     def get(preapproval_id, request_options: nil)
-      _get(uri: "/preapproval/#{preapproval_id}", request_options: request_options)
+      _get(uri: "/preapproval/#{_path_param(preapproval_id)}", request_options: request_options)
     end
 
     # Creates a new subscription.
@@ -58,7 +58,7 @@ module Mercadopago
     def update(preapproval_id, preapproval_data, request_options: nil)
       raise TypeError, 'Param preapproval_data must be a Hash' unless preapproval_data.is_a?(Hash)
 
-      _put(uri: "/preapproval/#{preapproval_id}", data: preapproval_data, request_options: request_options)
+      _put(uri: "/preapproval/#{_path_param(preapproval_id)}", data: preapproval_data, request_options: request_options)
     end
   end
 end

--- a/lib/mercadopago/resources/preapproval_plan.rb
+++ b/lib/mercadopago/resources/preapproval_plan.rb
@@ -30,7 +30,7 @@ module Mercadopago
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with plan details
     # @see https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/get-preapproval-plan/get
     def get(preapproval_plan_id, request_options: nil)
-      _get(uri: "/preapproval_plan/#{preapproval_plan_id}", request_options: request_options)
+      _get(uri: "/preapproval_plan/#{_path_param(preapproval_plan_id)}", request_options: request_options)
     end
 
     # Creates a new subscription plan.
@@ -57,7 +57,7 @@ module Mercadopago
     def update(preapproval_plan_id, preapproval_plan_data, request_options: nil)
       raise TypeError, 'Param preapproval_plan_data must be a Hash' unless preapproval_plan_data.is_a?(Hash)
 
-      _put(uri: "/preapproval_plan/#{preapproval_plan_id}", data: preapproval_plan_data, request_options: request_options)
+      _put(uri: "/preapproval_plan/#{_path_param(preapproval_plan_id)}", data: preapproval_plan_data, request_options: request_options)
     end
   end
 end

--- a/lib/mercadopago/resources/preference.rb
+++ b/lib/mercadopago/resources/preference.rb
@@ -17,7 +17,7 @@ module Mercadopago
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with preference details
     # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-pro/preferences/get-preference/get
     def get(preference_id, request_options: nil)
-      _get(uri: "/checkout/preferences/#{preference_id}", request_options: request_options)
+      _get(uri: "/checkout/preferences/#{_path_param(preference_id)}", request_options: request_options)
     end
 
     # Creates a new Checkout Pro preference.
@@ -44,7 +44,7 @@ module Mercadopago
     def update(preference_id, preference_data, request_options: nil)
       raise TypeError, 'Param preference_data must be a Hash' unless preference_data.is_a?(Hash)
 
-      _put(uri: "/checkout/preferences/#{preference_id}", data: preference_data, request_options: request_options)
+      _put(uri: "/checkout/preferences/#{_path_param(preference_id)}", data: preference_data, request_options: request_options)
     end
   end
 end

--- a/lib/mercadopago/resources/refund.rb
+++ b/lib/mercadopago/resources/refund.rb
@@ -17,7 +17,7 @@ module Mercadopago
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with an array of refunds
     # @see https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api-payments/get-refunds/get
     def list(payment_id, request_options: nil)
-      _get(uri: "/v1/payments/#{payment_id}/refunds", request_options: request_options)
+      _get(uri: "/v1/payments/#{_path_param(payment_id)}/refunds", request_options: request_options)
     end
 
     # Creates a full or partial refund on a payment.
@@ -34,7 +34,7 @@ module Mercadopago
     def create(payment_id, refund_data: nil, request_options: nil)
       raise TypeError, 'Param refund_data must be a Hash' unless refund_data.nil? || refund_data.is_a?(Hash)
 
-      _post(uri: "/v1/payments/#{payment_id}/refunds", data: refund_data, request_options: request_options)
+      _post(uri: "/v1/payments/#{_path_param(payment_id)}/refunds", data: refund_data, request_options: request_options)
     end
   end
 end

--- a/tests/test_path_param.rb
+++ b/tests/test_path_param.rb
@@ -1,0 +1,14 @@
+# typed: true
+# frozen_string_literal: true
+
+require_relative '../lib/mercadopago'
+
+require 'minitest/autorun'
+
+class TestPathParam < Minitest::Test
+  def test_path_param_escapes_path_traversal
+    base = Mercadopago::MPBase.new(Mercadopago::RequestOptions.new(access_token: 'token'), nil)
+
+    assert_equal '..%2F..%2Fapplications%2F123', base.send(:_path_param, '../../applications/123')
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a shared path-parameter encoder in MPBase.
- Applies encoding to dynamic IDs across affected resources.
- Adds regression coverage for traversal-style path parameters.

## Validation
- Not run locally: this checkout requires Ruby 3.4.3 via .ruby-version, which is not installed in the local rbenv environment.