### PR TITLE
Bump version to 3.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mercadopago-sdk (3.2.0)
+    mercadopago-sdk (3.2.1)
       faraday (~> 2.0)
       json (~> 2.5)
 

--- a/mercadopago.gemspec
+++ b/mercadopago.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name                  = 'mercadopago-sdk'
-  gem.version               = '3.2.0'
+  gem.version               = '3.2.1'
   gem.required_ruby_version = '>= 3.3.0'
   gem.author                = 'Mercado Pago'
   gem.description           = 'Mercado Pago Ruby SDK'


### PR DESCRIPTION
## Summary
- Bump patch version from 3.2.0 to 3.2.1

## Files changed
- `mercadopago.gemspec` — `gem.version` updated to 3.2.1
- `Gemfile.lock` — version updated to 3.2.1

## Test plan
- [ ] Verify CI passes
- [ ] Confirm version string is correct in all files