### PR TITLE
Pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         ref: ${{ github.event.pull_request.head.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
 
     - name: Cache gems
-      uses: actions/cache@v6
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v6
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install dependencies
         run: bundle install

--- a/lib/mercadopago/resources/order_transaction.rb
+++ b/lib/mercadopago/resources/order_transaction.rb
@@ -34,7 +34,8 @@ module Mercadopago
     def update(order_id, transaction_id, order_transaction_data, request_options: nil)
       raise TypeError, 'Param order_transaction_data must be a Hash' unless order_transaction_data.is_a?(Hash)
 
-      _put(uri: "/v1/orders/#{_path_param(order_id)}/transactions/#{_path_param(transaction_id)}", data: order_transaction_data, request_options: request_options)
+      _put(uri: "/v1/orders/#{_path_param(order_id)}/transactions/#{_path_param(transaction_id)}",
+           data: order_transaction_data, request_options: request_options)
     end
 
     # Removes a transaction from an order.


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full SHA commit hashes to prevent supply chain attacks via mutable tags

## Changes
- `ci.yml`: `actions/checkout@v7` → `@9c091bb2...`, `actions/cache@v6` → `@caa29612...`
- `release.yml`: `actions/checkout@v7` → `@9c091bb2...`

## Test plan
- [ ] CI passes on this PR