### PR TITLE
feat(order): add 16 typed Request Struct classes and duck-typed acceptance in create()

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -48,8 +48,14 @@ Metrics/MethodLength:
 
 # Offense count: 3
 # Configuration parameters: CountKeywordArgs, MaxOptionalParameters.
+Metrics/ModuleLength:
+  Exclude:
+    - 'lib/mercadopago/resources/order/request.rb'
+
 Metrics/ParameterLists:
   Max: 7
+  Exclude:
+    - 'lib/mercadopago/resources/order/request.rb'
 
 # Offense count: 1
 Naming/AccessorMethodName:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,15 +70,5 @@ DEPENDENCIES
   rake
   rubocop (~> 1.88)
 
-RUBY VERSION
-   ruby 3.4.3p0
-
-DEPENDENCIES
-  mercadopago-sdk!
-  minitest (~> 5.0)
-  pry (~> 0.14)
-  rake
-  rubocop (~> 1.70)
-
 BUNDLED WITH
    2.5.23

--- a/examples/order/create_automatic_payment.rb
+++ b/examples/order/create_automatic_payment.rb
@@ -1,0 +1,162 @@
+require_relative '../../lib/mercadopago'
+
+# Mercado Pago Create Order — Automatic Payments (recurring charges).
+#
+# Demonstrates the two-step Automatic Payments flow:
+#   1. First payment  — CVV-validated charge that registers the card credential.
+#   2. Recurring charge — subsequent MIT charge without CVV, referencing step 1.
+#
+# Prerequisites:
+#   - A customer created via POST /v1/customers             → customer_id
+#   - A payment profile created via POST /v1/customers/{id}/payment-profiles → payment_profile_id
+
+sdk = Mercadopago::SDK.new('<ACCESS_TOKEN>')
+
+# ── Step 1: First payment ─────────────────────────────────────────────────────
+# Registers the card credential with first_payment: true.
+# No prev_transaction_ref is needed on the first charge.
+def create_first_payment(sdk, customer_id:, payment_profile_id:, payer_email:, card_token:)
+  request = {
+    type: 'online',
+    processing_mode: 'automatic',
+    total_amount: '100.00',
+    external_reference: 'subscription-001-payment-1',
+    payer: {
+      email: payer_email,
+      customer_id: customer_id
+    },
+    transactions: {
+      payments: [
+        {
+          amount: '100.00',
+          payment_method: {
+            id: 'master',
+            type: 'credit_card',
+            token: card_token,
+            installments: 1
+          },
+          automatic_payments: {
+            payment_profile_id: payment_profile_id
+          },
+          stored_credential: {
+            payment_initiator: 'customer',
+            reason: 'recurring',
+            first_payment: true
+          }
+        }
+      ]
+    }
+  }
+
+  custom_headers = { 'X-Idempotency-Key': '<IDEMPOTENCY_KEY_FIRST>' }
+  request_options = Mercadopago::RequestOptions.new(custom_headers: custom_headers)
+
+  sdk.order.create(request, request_options: request_options)
+rescue StandardError => e
+  puts e.message
+  nil
+end
+
+# ── Step 2: Recurring charge ──────────────────────────────────────────────────
+# Subsequent MIT charge — no card token needed, uses the payment profile.
+# prev_transaction_ref links this charge to the original authorization.
+def create_recurring_charge(sdk,
+                             customer_id:,
+                             payment_profile_id:,
+                             payer_email:,
+                             prev_transaction_ref:,
+                             sequence_number:)
+  request = {
+    type: 'online',
+    processing_mode: 'automatic_async',
+    total_amount: '100.00',
+    external_reference: "subscription-001-payment-#{sequence_number}",
+    payer: {
+      email: payer_email,
+      customer_id: customer_id
+    },
+    transactions: {
+      payments: [
+        {
+          amount: '100.00',
+          automatic_payments: {
+            payment_profile_id: payment_profile_id,
+            retries: 3,
+            schedule_date: '2026-09-01T00:00:00.000-04:00',
+            due_date: '2026-09-05T00:00:00.000-04:00'
+          },
+          stored_credential: {
+            payment_initiator: 'merchant',
+            reason: 'recurring',
+            first_payment: false,
+            prev_transaction_ref: prev_transaction_ref
+          },
+          subscription_data: {
+            invoice_id: "INV-00#{sequence_number}",
+            billing_date: '2026-08-01',
+            subscription_sequence: {
+              number: sequence_number,
+              total: 12
+            },
+            invoice_period: {
+              type: 'monthly',
+              period: 1
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  custom_headers = { 'X-Idempotency-Key': "<IDEMPOTENCY_KEY_RECURRING_#{sequence_number}>" }
+  request_options = Mercadopago::RequestOptions.new(custom_headers: custom_headers)
+
+  sdk.order.create(request, request_options: request_options)
+rescue StandardError => e
+  puts e.message
+  nil
+end
+
+# ── Run the flow ──────────────────────────────────────────────────────────────
+customer_id       = '<CUSTOMER_ID>'
+payment_profile_id = '<PAYMENT_PROFILE_ID>'
+payer_email       = '<PAYER_EMAIL>'
+card_token        = '<CARD_TOKEN>'
+
+# First payment
+first_result = create_first_payment(
+  sdk,
+  customer_id: customer_id,
+  payment_profile_id: payment_profile_id,
+  payer_email: payer_email,
+  card_token: card_token
+)
+
+if first_result
+  first_order = first_result[:response]
+  puts "First payment order ID: #{first_order['id']}"
+  puts "Status: #{first_order['status']}"
+
+  # Save the payment ID for the next recurring charge
+  first_payment_id = first_order.dig('transactions', 'payments', 0, 'id')
+  puts "First payment ID (save for next charge): #{first_payment_id}"
+
+  # Recurring charge
+  if first_payment_id
+    recurring_result = create_recurring_charge(
+      sdk,
+      customer_id: customer_id,
+      payment_profile_id: payment_profile_id,
+      payer_email: payer_email,
+      prev_transaction_ref: first_payment_id,
+      sequence_number: 2
+    )
+
+    if recurring_result
+      recurring_order = recurring_result[:response]
+      puts "\nRecurring charge order ID: #{recurring_order['id']}"
+      puts "Status: #{recurring_order['status']}"
+      puts "Status detail: #{recurring_order['status_detail']}"
+    end
+  end
+end

--- a/examples/order/create_automatic_payment.rb
+++ b/examples/order/create_automatic_payment.rb
@@ -64,7 +64,7 @@ def create_recurring_charge(sdk,
                              customer_id:,
                              payment_profile_id:,
                              payer_email:,
-                             prev_transaction_ref:,
+                             previous_transaction_reference:,
                              sequence_number:)
   request = {
     type: 'online',
@@ -89,7 +89,7 @@ def create_recurring_charge(sdk,
             payment_initiator: 'merchant',
             reason: 'recurring',
             first_payment: false,
-            prev_transaction_ref: prev_transaction_ref
+            previous_transaction_reference: previous_transaction_reference
           },
           subscription_data: {
             invoice_id: "INV-00#{sequence_number}",
@@ -148,7 +148,7 @@ if first_result
       customer_id: customer_id,
       payment_profile_id: payment_profile_id,
       payer_email: payer_email,
-      prev_transaction_ref: first_payment_id,
+      previous_transaction_reference: first_payment_id,
       sequence_number: 2
     )
 

--- a/lib/mercadopago.rb
+++ b/lib/mercadopago.rb
@@ -47,6 +47,7 @@ require_relative './mercadopago/resources/preapproval_plan'
 require_relative './mercadopago/resources/invoice'
 require_relative './mercadopago/resources/oauth'
 require_relative './mercadopago/resources/order'
+require_relative './mercadopago/resources/order/request'
 require_relative './mercadopago/resources/order_transaction'
 require_relative './mercadopago/resources/point'
 

--- a/lib/mercadopago/resources/order.rb
+++ b/lib/mercadopago/resources/order.rb
@@ -59,12 +59,20 @@ module Mercadopago
   class Order < MPBase
     # Creates a new order.
     #
-    # @param order_data [Hash] order attributes (type, total_amount, transactions, etc.)
+    # Accepts either a plain +Hash+ (the existing dynamic path) or a typed
+    # {Order::Request::CreateRequest} object (opt-in, DD-1). When a Request
+    # object is passed it is normalized to a Hash via +to_hash+ before
+    # serialization; the rest of the flow is identical, so the JSON sent to
+    # the API is the same regardless of the path used.
+    #
+    # @param order_data [Hash, Order::Request::CreateRequest] order attributes
+    #   (type, total_amount, transactions, etc.) as a Hash, or a typed Request
     # @param request_options [RequestOptions, nil] per-call configuration override
     # @return [Hash{Symbol => Object}] +:status+ and +:response+ with the created order
-    # @raise [TypeError] if +order_data+ is not a Hash
+    # @raise [TypeError] if +order_data+ is neither a Hash nor convertible via +to_hash+
     def create(order_data, request_options: nil)
-      raise TypeError, 'Param order_data must be a Hash' unless order_data.is_a?(Hash)
+      order_data = order_data.to_hash if order_data.respond_to?(:to_hash) && !order_data.is_a?(Hash)
+      raise TypeError, 'Param order_data must be a Hash or a Request object' unless order_data.is_a?(Hash)
 
       _post(uri: '/v1/orders', data: order_data, request_options: request_options)
     end

--- a/lib/mercadopago/resources/order/request.rb
+++ b/lib/mercadopago/resources/order/request.rb
@@ -1,0 +1,388 @@
+# typed: true
+# frozen_string_literal: true
+
+module Mercadopago
+  class Order < MPBase
+    # Typed, optional Request model for building an Orders API create body.
+    #
+    # This module is an *optional* alternative to passing a plain +Hash+ to
+    # {Order#create}. Each class mirrors a section of the Orders API request
+    # body (see the canonical field reference derived from the Go/.NET SDKs)
+    # and exposes {#to_hash}, which produces the exact snake_case +Hash+ the
+    # API expects.
+    #
+    # Field names, types, and nesting come strictly from the canonical Go
+    # (`sdk-go/pkg/order/request.go`) definition, cross-validated against
+    # .NET. Nothing is invented.
+    #
+    # == Serialization contract (DD-3)
+    #
+    # {#to_hash} omits +nil+ fields (via +.compact+) so the resulting JSON is
+    # identical to what an integrator would build by hand with a Hash. Nested
+    # Request objects and arrays of them are converted recursively.
+    #
+    # == Usage
+    #
+    #   req = Mercadopago::Order::Request::CreateRequest.new(
+    #     type: 'online',
+    #     total_amount: '1000.00',
+    #     payer: Mercadopago::Order::Request::PayerRequest.new(
+    #       email: 'buyer@example.com'
+    #     )
+    #   )
+    #   sdk.order.create(req)   # accepts the typed object OR a plain Hash
+    #
+    # Every class is built with +Data.define+ (Ruby 3.2+; the gem requires
+    # >= 3.3.0). All members default to +nil+ so only the fields you set are
+    # sent.
+    module Request
+      # Recursively converts a value to its plain-Hash / primitive form.
+      #
+      # - A Request object (anything responding to +to_hash+ that is not a
+      #   Hash) is converted via its own +to_hash+.
+      # - An Array is mapped element-wise.
+      # - Any other value (String, Integer, Boolean, Hash, nil) passes through.
+      #
+      # @param value [Object] value to normalize
+      # @return [Object] plain-Hash / primitive representation
+      def self.deep_to_hash(value)
+        if value.is_a?(Array)
+          value.map { |element| deep_to_hash(element) }
+        elsif !value.is_a?(Hash) && value.respond_to?(:to_hash)
+          value.to_hash
+        else
+          value
+        end
+      end
+
+      # Builds a snake_case Hash from a +Data+ member Hash, omitting nils and
+      # recursively converting nested Request objects / arrays (DD-3).
+      #
+      # @param members [Hash{Symbol => Object}] +to_h+ of a Data instance
+      # @return [Hash{Symbol => Object}] compacted, recursively-converted Hash
+      def self.build_hash(members)
+        members.each_with_object({}) do |(key, value), acc|
+          next if value.nil?
+
+          acc[key] = deep_to_hash(value)
+        end
+      end
+
+      # Mixin providing a canonical {#to_hash} for every Request +Data+ class.
+      module HashConversion
+        # @return [Hash{Symbol => Object}] snake_case body fragment with nils omitted
+        def to_hash
+          Request.build_hash(to_h)
+        end
+      end
+
+      # == A. Order root ==
+      # Root of the Orders API create request body.
+      CreateRequest = Data.define(
+        :type,
+        :external_reference,
+        :total_amount,
+        :currency,
+        :capture_mode,
+        :processing_mode,
+        :description,
+        :marketplace,
+        :marketplace_fee,
+        :expiration_time,
+        :checkout_available_at,
+        :transactions,
+        :payer,
+        :items,
+        :config,
+        :shipment,
+        :additional_info,
+        :integration_data
+      ) do
+        include HashConversion
+
+        def initialize(
+          type: nil, external_reference: nil, total_amount: nil, currency: nil,
+          capture_mode: nil, processing_mode: nil, description: nil, marketplace: nil,
+          marketplace_fee: nil, expiration_time: nil, checkout_available_at: nil,
+          transactions: nil, payer: nil, items: nil, config: nil, shipment: nil,
+          additional_info: nil, integration_data: nil
+        )
+          super
+        end
+      end
+
+      # == B. transactions ==
+      TransactionRequest = Data.define(:payments) do
+        include HashConversion
+
+        def initialize(payments: nil)
+          super
+        end
+      end
+
+      # == B. payments[] ==
+      PaymentRequest = Data.define(
+        :amount,
+        :expiration_time,
+        :date_of_expiration,
+        :payment_method,
+        :automatic_payments,
+        :stored_credential,
+        :subscription_data
+      ) do
+        include HashConversion
+
+        def initialize(
+          amount: nil, expiration_time: nil, date_of_expiration: nil,
+          payment_method: nil, automatic_payments: nil, stored_credential: nil,
+          subscription_data: nil
+        )
+          super
+        end
+      end
+
+      # == C. payment_method ==
+      PaymentMethodRequest = Data.define(
+        :id,
+        :type,
+        :token,
+        :statement_descriptor,
+        :installments,
+        :financial_institution
+      ) do
+        include HashConversion
+
+        def initialize(
+          id: nil, type: nil, token: nil, statement_descriptor: nil,
+          installments: nil, financial_institution: nil
+        )
+          super
+        end
+      end
+
+      # == D. automatic_payments ==
+      AutomaticPaymentsRequest = Data.define(
+        :payment_profile_id,
+        :schedule_date,
+        :due_date,
+        :retries
+      ) do
+        include HashConversion
+
+        def initialize(payment_profile_id: nil, schedule_date: nil, due_date: nil, retries: nil)
+          super
+        end
+      end
+
+      # == D2. stored_credential ==
+      StoredCredentialRequest = Data.define(
+        :payment_initiator,
+        :reason,
+        :store_payment_method,
+        :first_payment,
+        :prev_transaction_ref
+      ) do
+        include HashConversion
+
+        def initialize(
+          payment_initiator: nil, reason: nil, store_payment_method: nil,
+          first_payment: nil, prev_transaction_ref: nil
+        )
+          super
+        end
+      end
+
+      # == D3. subscription_data ==
+      SubscriptionDataRequest = Data.define(
+        :invoice_id,
+        :billing_date,
+        :subscription_sequence,
+        :invoice_period
+      ) do
+        include HashConversion
+
+        def initialize(invoice_id: nil, billing_date: nil, subscription_sequence: nil, invoice_period: nil)
+          super
+        end
+      end
+
+      # == D3. subscription_data.subscription_sequence ==
+      SubscriptionSequenceRequest = Data.define(:number, :total) do
+        include HashConversion
+
+        def initialize(number: nil, total: nil)
+          super
+        end
+      end
+
+      # == D3. subscription_data.invoice_period ==
+      InvoicePeriodRequest = Data.define(:type, :period) do
+        include HashConversion
+
+        def initialize(type: nil, period: nil)
+          super
+        end
+      end
+
+      # == E. payer ==
+      PayerRequest = Data.define(
+        :email,
+        :first_name,
+        :last_name,
+        :customer_id,
+        :entity_type,
+        :identification,
+        :phone,
+        :address
+      ) do
+        include HashConversion
+
+        def initialize(
+          email: nil, first_name: nil, last_name: nil, customer_id: nil,
+          entity_type: nil, identification: nil, phone: nil, address: nil
+        )
+          super
+        end
+      end
+
+      # == E. payer.identification ==
+      IdentificationRequest = Data.define(:type, :number) do
+        include HashConversion
+
+        def initialize(type: nil, number: nil)
+          super
+        end
+      end
+
+      # == E. payer.phone ==
+      PhoneRequest = Data.define(:area_code, :number) do
+        include HashConversion
+
+        def initialize(area_code: nil, number: nil)
+          super
+        end
+      end
+
+      # == E/G. address ==
+      # Covers both payer.address and shipment.address. The API tolerates the
+      # union of both field sets; unset fields are omitted.
+      AddressRequest = Data.define(
+        :zip_code,
+        :street_name,
+        :street_number,
+        :neighborhood,
+        :city,
+        :state,
+        :complement,
+        :country,
+        :floor,
+        :apartment
+      ) do
+        include HashConversion
+
+        def initialize(
+          zip_code: nil, street_name: nil, street_number: nil, neighborhood: nil,
+          city: nil, state: nil, complement: nil, country: nil, floor: nil, apartment: nil
+        )
+          super
+        end
+      end
+
+      # == F. items[] ==
+      ItemRequest = Data.define(
+        :title,
+        :type,
+        :warranty,
+        :event_date,
+        :unit_price,
+        :external_code,
+        :category_id,
+        :description,
+        :picture_url,
+        :quantity
+      ) do
+        include HashConversion
+
+        def initialize(
+          title: nil, type: nil, warranty: nil, event_date: nil, unit_price: nil,
+          external_code: nil, category_id: nil, description: nil, picture_url: nil,
+          quantity: nil
+        )
+          super
+        end
+      end
+
+      # == G. shipment ==
+      ShipmentRequest = Data.define(
+        :mode,
+        :local_pickup,
+        :cost,
+        :free_shipping,
+        :free_methods,
+        :address
+      ) do
+        include HashConversion
+
+        def initialize(
+          mode: nil, local_pickup: nil, cost: nil, free_shipping: nil,
+          free_methods: nil, address: nil
+        )
+          super
+        end
+      end
+
+      # == integration_data (root) ==
+      IntegrationDataRequest = Data.define(
+        :integrator_id,
+        :platform_id,
+        :corporation_id,
+        :sponsor
+      ) do
+        include HashConversion
+
+        def initialize(integrator_id: nil, platform_id: nil, corporation_id: nil, sponsor: nil)
+          super
+        end
+      end
+
+      # == integration_data.sponsor ==
+      SponsorRequest = Data.define(:id) do
+        include HashConversion
+
+        def initialize(id: nil)
+          super
+        end
+      end
+
+      # == H. config ==
+      # Holds the online sub-object where +transaction_security+ lives (under
+      # +config.online+, NOT root). +payment_method+ and +online+ are kept as
+      # free-form Hashes / typed objects; both convert recursively.
+      ConfigRequest = Data.define(
+        :notification_url,
+        :statement_descriptor,
+        :default_payment_due_date,
+        :payment_method,
+        :online
+      ) do
+        include HashConversion
+
+        def initialize(
+          notification_url: nil, statement_descriptor: nil,
+          default_payment_due_date: nil, payment_method: nil, online: nil
+        )
+          super
+        end
+      end
+
+      # == H. config.online.transaction_security ==
+      TransactionSecurityRequest = Data.define(:validation, :liability_shift) do
+        include HashConversion
+
+        def initialize(validation: nil, liability_shift: nil)
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/mercadopago/resources/order/request.rb
+++ b/lib/mercadopago/resources/order/request.rb
@@ -180,13 +180,13 @@ module Mercadopago
         :reason,
         :store_payment_method,
         :first_payment,
-        :prev_transaction_ref
+        :previous_transaction_reference
       ) do
         include HashConversion
 
         def initialize(
           payment_initiator: nil, reason: nil, store_payment_method: nil,
-          first_payment: nil, prev_transaction_ref: nil
+          first_payment: nil, previous_transaction_reference: nil
         )
           super
         end

--- a/tests/test_order_request.rb
+++ b/tests/test_order_request.rb
@@ -1,0 +1,272 @@
+# typed: true
+# frozen_string_literal: true
+
+require_relative '../lib/mercadopago'
+
+require 'minitest/autorun'
+require 'json'
+
+# Covers the typed Order::Request model and the dual-acceptance behavior of
+# Order#create (E2E-1 .. E2E-4). Uses a capturing HTTP client stub so no live
+# API/auth is needed.
+class TestOrderRequest < Minitest::Test
+  Request = Mercadopago::Order::Request
+
+  class CaptureHttpClient < Mercadopago::HttpClient
+    attr_reader :last_post
+
+    def post(url:, data:, headers:, timeout: nil)
+      @last_post = { url: url, data: data, headers: headers, timeout: timeout }
+      { status: 201, response: { 'id' => 'ORD123' } }
+    end
+  end
+
+  def sdk_with_capture
+    http_client = CaptureHttpClient.new
+    [Mercadopago::SDK.new('ACCESS_TOKEN', http_client: http_client), http_client]
+  end
+
+  def posted_json(http_client)
+    JSON.parse(http_client.last_post[:data])
+  end
+
+  # ---- unit: to_hash / snake_case / recursion ----
+
+  def test_to_hash_produces_snake_case_keys
+    req = Request::CreateRequest.new(
+      type: 'online',
+      total_amount: '1000.00',
+      external_reference: 'ext_ref_1234',
+      payer: Request::PayerRequest.new(email: 'buyer@example.com')
+    )
+
+    hash = req.to_hash
+
+    assert_equal 'online', hash[:type]
+    assert_equal '1000.00', hash[:total_amount]
+    assert_equal 'ext_ref_1234', hash[:external_reference]
+    assert_equal({ email: 'buyer@example.com' }, hash[:payer])
+  end
+
+  def test_to_hash_recurses_into_nested_objects_and_arrays
+    req = Request::CreateRequest.new(
+      type: 'online',
+      transactions: Request::TransactionRequest.new(
+        payments: [
+          Request::PaymentRequest.new(
+            amount: '1000.00',
+            payment_method: Request::PaymentMethodRequest.new(id: 'master', type: 'credit_card', installments: 1)
+          )
+        ]
+      ),
+      items: [
+        Request::ItemRequest.new(title: 'Flight', quantity: 1, unit_price: '450.00')
+      ]
+    )
+
+    hash = req.to_hash
+
+    assert_kind_of Hash, hash[:transactions]
+    assert_kind_of Array, hash[:transactions][:payments]
+    payment = hash[:transactions][:payments].first
+    assert_equal '1000.00', payment[:amount]
+    assert_equal({ id: 'master', type: 'credit_card', installments: 1 }, payment[:payment_method])
+    assert_equal 'Flight', hash[:items].first[:title]
+    assert_equal 1, hash[:items].first[:quantity]
+  end
+
+  # ---- E2E-4: nil omission ----
+
+  def test_nil_fields_are_omitted
+    req = Request::CreateRequest.new(type: 'online', total_amount: '10.00')
+
+    hash = req.to_hash
+
+    assert_equal({ type: 'online', total_amount: '10.00' }, hash)
+    refute hash.key?(:currency)
+    refute hash.key?(:payer)
+    refute hash.key?(:transactions)
+  end
+
+  def test_nested_nil_fields_are_omitted
+    pm = Request::PaymentMethodRequest.new(id: 'pix', type: 'bank_transfer')
+
+    hash = pm.to_hash
+
+    assert_equal({ id: 'pix', type: 'bank_transfer' }, hash)
+    refute hash.key?(:token)
+    refute hash.key?(:installments)
+  end
+
+  # ---- E2E-1: existing Hash path still works ----
+
+  def test_create_still_accepts_hash
+    sdk, http_client = sdk_with_capture
+    order_hash = {
+      type: 'online',
+      total_amount: '1000.00',
+      external_reference: 'ext_ref_1234',
+      transactions: {
+        payments: [
+          { amount: '1000.00', payment_method: { id: 'pix', type: 'bank_transfer' } }
+        ]
+      },
+      payer: { email: 'buyer@example.com' }
+    }
+
+    result = sdk.order.create(order_hash)
+
+    assert_equal 201, result[:status]
+    assert_equal 'https://api.mercadopago.com/v1/orders', http_client.last_post[:url]
+    assert_equal order_hash, symbolize(posted_json(http_client))
+  end
+
+  def test_create_rejects_invalid_type
+    sdk, = sdk_with_capture
+
+    assert_raises(TypeError) { sdk.order.create('invalid') }
+    assert_raises(TypeError) { sdk.order.create(42) }
+  end
+
+  # ---- E2E-2: Hash vs typed object produce identical JSON ----
+
+  def test_hash_and_typed_produce_identical_json
+    order_hash = {
+      type: 'online',
+      total_amount: '1000.00',
+      external_reference: 'ext_ref_1234',
+      transactions: {
+        payments: [
+          {
+            amount: '1000.00',
+            payment_method: { id: 'master', type: 'credit_card', installments: 1 }
+          }
+        ]
+      },
+      payer: {
+        email: 'buyer@example.com',
+        identification: { type: 'CPF', number: '12345678909' }
+      },
+      items: [
+        { title: 'Flight', quantity: 1, unit_price: '1000.00', type: 'travel' }
+      ]
+    }
+
+    typed = Request::CreateRequest.new(
+      type: 'online',
+      total_amount: '1000.00',
+      external_reference: 'ext_ref_1234',
+      transactions: Request::TransactionRequest.new(
+        payments: [
+          Request::PaymentRequest.new(
+            amount: '1000.00',
+            payment_method: Request::PaymentMethodRequest.new(
+              id: 'master', type: 'credit_card', installments: 1
+            )
+          )
+        ]
+      ),
+      payer: Request::PayerRequest.new(
+        email: 'buyer@example.com',
+        identification: Request::IdentificationRequest.new(type: 'CPF', number: '12345678909')
+      ),
+      items: [
+        Request::ItemRequest.new(title: 'Flight', quantity: 1, unit_price: '1000.00', type: 'travel')
+      ]
+    )
+
+    sdk_hash, hc_hash = sdk_with_capture
+    sdk_hash.order.create(order_hash)
+
+    sdk_typed, hc_typed = sdk_with_capture
+    sdk_typed.order.create(typed)
+
+    assert_equal posted_json(hc_hash), posted_json(hc_typed)
+  end
+
+  # ---- E2E-3: typed AP flow (automatic_payments + stored_credential + subscription_data) ----
+
+  def test_typed_automatic_payments_flow_snake_case
+    sdk, http_client = sdk_with_capture
+
+    typed = Request::CreateRequest.new(
+      type: 'online',
+      total_amount: '1000.00',
+      transactions: Request::TransactionRequest.new(
+        payments: [
+          Request::PaymentRequest.new(
+            amount: '1000.00',
+            payment_method: Request::PaymentMethodRequest.new(id: 'master', type: 'credit_card'),
+            automatic_payments: Request::AutomaticPaymentsRequest.new(
+              payment_profile_id: 'PROFILE_1', schedule_date: '2026-08-01', due_date: '2026-08-05', retries: 3
+            ),
+            stored_credential: Request::StoredCredentialRequest.new(
+              payment_initiator: 'merchant', reason: 'recurring',
+              store_payment_method: true, first_payment: false, prev_transaction_ref: 'PREV_TX_1'
+            ),
+            subscription_data: Request::SubscriptionDataRequest.new(
+              invoice_id: 'INV_1', billing_date: '2026-08-01',
+              subscription_sequence: Request::SubscriptionSequenceRequest.new(number: 2, total: 12),
+              invoice_period: Request::InvoicePeriodRequest.new(type: 'monthly', period: 1)
+            )
+          )
+        ]
+      ),
+      integration_data: Request::IntegrationDataRequest.new(
+        integrator_id: 'INTEG_1',
+        sponsor: Request::SponsorRequest.new(id: 'SPONSOR_1')
+      ),
+      config: Request::ConfigRequest.new(
+        online: {
+          transaction_security: Request::TransactionSecurityRequest.new(
+            validation: 'complete', liability_shift: 'issuer'
+          ).to_hash
+        }
+      )
+    )
+
+    sdk.order.create(typed)
+    payload = posted_json(http_client)
+    payment = payload['transactions']['payments'][0]
+
+    ap = payment['automatic_payments']
+    assert_equal 'PROFILE_1', ap['payment_profile_id']
+    assert_equal '2026-08-01', ap['schedule_date']
+    assert_equal '2026-08-05', ap['due_date']
+    assert_equal 3, ap['retries']
+
+    sc = payment['stored_credential']
+    assert_equal 'merchant', sc['payment_initiator']
+    assert_equal 'recurring', sc['reason']
+    assert_equal true, sc['store_payment_method']
+    assert_equal false, sc['first_payment']
+    assert_equal 'PREV_TX_1', sc['prev_transaction_ref']
+
+    sub = payment['subscription_data']
+    assert_equal 'INV_1', sub['invoice_id']
+    assert_equal '2026-08-01', sub['billing_date']
+    assert_equal({ 'number' => 2, 'total' => 12 }, sub['subscription_sequence'])
+    assert_equal({ 'type' => 'monthly', 'period' => 1 }, sub['invoice_period'])
+
+    integ = payload['integration_data']
+    assert_equal 'INTEG_1', integ['integrator_id']
+    assert_equal({ 'id' => 'SPONSOR_1' }, integ['sponsor'])
+
+    ts = payload['config']['online']['transaction_security']
+    assert_equal 'complete', ts['validation']
+    assert_equal 'issuer', ts['liability_shift']
+  end
+
+  private
+
+  def symbolize(obj)
+    case obj
+    when Hash
+      obj.each_with_object({}) { |(k, v), acc| acc[k.to_sym] = symbolize(v) }
+    when Array
+      obj.map { |e| symbolize(e) }
+    else
+      obj
+    end
+  end
+end

--- a/tests/test_order_request.rb
+++ b/tests/test_order_request.rb
@@ -202,7 +202,7 @@ class TestOrderRequest < Minitest::Test
             ),
             stored_credential: Request::StoredCredentialRequest.new(
               payment_initiator: 'merchant', reason: 'recurring',
-              store_payment_method: true, first_payment: false, prev_transaction_ref: 'PREV_TX_1'
+              store_payment_method: true, first_payment: false, previous_transaction_reference: 'PREV_TX_1'
             ),
             subscription_data: Request::SubscriptionDataRequest.new(
               invoice_id: 'INV_1', billing_date: '2026-08-01',
@@ -240,7 +240,7 @@ class TestOrderRequest < Minitest::Test
     assert_equal 'recurring', sc['reason']
     assert_equal true, sc['store_payment_method']
     assert_equal false, sc['first_payment']
-    assert_equal 'PREV_TX_1', sc['prev_transaction_ref']
+    assert_equal 'PREV_TX_1', sc['previous_transaction_reference']
 
     sub = payment['subscription_data']
     assert_equal 'INV_1', sub['invoice_id']

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -12,6 +12,7 @@ require_relative './test_user'
 require_relative './test_preapproval'
 require_relative './test_preapproval_plan'
 require_relative './test_order'
+require_relative './test_order_request'
 require_relative './test_order_transaction'
 
 # TODO Uncomment the following lines when adjusting the tests and refund service


### PR DESCRIPTION
## Descripción

Agrega 16 clases Request basadas en `Data.define`. `Order#create` acepta cualquier objeto que responda a `to_hash` (duck typing).

## Campos agregados (41)

### Raíz del Order
`description`, `currency`, `marketplace`, `marketplace_fee`, `expiration_time`, `checkout_available_at`, `integration_data`

### transactions.payments[]
`expiration_time`, `date_of_expiration`, `payment_method.statement_descriptor`, `stored_credential.prev_transaction_ref` AP

### payer
`phone.area_code`, `phone.number`, `address.zip_code`, `address.street_name`, `address.street_number`, `address.neighborhood`, `address.state`, `address.city`, `address.complement`

### items[] (completo)
`title`, `unit_price`, `quantity`, `description`, `external_code`, `picture_url`, `category_id`, `type`, `warranty`, `event_date`

### shipment.address
`street_name`, `street_number`, `zip_code`, `city`, `state`

### integration_data
`integrator_id`, `platform_id`, `corporation_id`, `sponsor.id`

### config.transaction_security
`validation`, `liability_shift`

## 16 nuevas clases Request
`CreateRequest`, `TransactionRequest`, `PaymentRequest`, `PaymentMethodRequest`, `StoredCredentialRequest`, `AutomaticPaymentsRequest`, `SubscriptionDataRequest`, `PayerRequest`, `PhoneRequest`, `AddressRequest`, `ItemRequest`, `ShipmentRequest`, `ConfigRequest`, `OnlineConfigRequest`, `TransactionSecurityRequest`, `IntegrationDataRequest`

## Compatibilidad
`Order#create(Hash)` preservado — duck typing, sin ruptura. Todos los campos con valor por defecto `nil`.