### PR TITLE
chore: bump version to 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2026-08-11
+
+### Added
+- **Automatic Payments example**: two-step recurring flow ([#156](https://github.com/mercadopago/sdk-ruby/pull/156))
+- **Pagination**: support `data` key for Orders v2 API and string paging totals ([#156](https://github.com/mercadopago/sdk-ruby/pull/156))
+
+### Fixed
+- **Stored credential**: rename `prev_transaction_ref` to `previous_transaction_reference` ([#156](https://github.com/mercadopago/sdk-ruby/pull/156))
+- **`Iterator#call`**: use keyword args for Ruby 4.0 strict kwarg separation ([#156](https://github.com/mercadopago/sdk-ruby/pull/156))
+
+### CI
+- Standardize CI/CD workflows ([#166](https://github.com/mercadopago/sdk-ruby/pull/166))
+- Migrate tests to mock-based unit tests ([#166](https://github.com/mercadopago/sdk-ruby/pull/166))
+- Fix SDK bugs discovered during mock test migration ([#166](https://github.com/mercadopago/sdk-ruby/pull/166))
+- Fix Ruby CI: drop 3.2 matrix (gemspec requires >=3.3), add `safe.directory` ([#166](https://github.com/mercadopago/sdk-ruby/pull/166))
+
 ## [3.3.0] - 2026-08-04
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mercadopago-sdk (3.3.0)
+    mercadopago-sdk (3.4.0)
       faraday (~> 2.0)
       json (~> 2.5)
 

--- a/mercadopago.gemspec
+++ b/mercadopago.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name                  = 'mercadopago-sdk'
-  gem.version               = '3.3.0'
+  gem.version               = '3.4.0'
   gem.required_ruby_version = '>= 3.3.0'
   gem.author                = 'Mercado Pago'
   gem.description           = 'Mercado Pago Ruby SDK'


### PR DESCRIPTION
## Summary
- Bump version from \`3.3.0\` to \`3.4.0\`
- Update \`mercadopago.gemspec\`, \`Gemfile.lock\`, \`CHANGELOG.md\`

## Changelog entry
### Added
- Automatic Payments example: two-step recurring flow ([#156](https://github.com/mercadopago/sdk-ruby/pull/156))
- Pagination: support \`data\` key for Orders v2 API and string paging totals ([#156](https://github.com/mercadopago/sdk-ruby/pull/156))
### Fixed
- Stored credential: rename \`prev_transaction_ref\` to \`previous_transaction_reference\` ([#156](https://github.com/mercadopago/sdk-ruby/pull/156))
- \`Iterator#call\`: use keyword args for Ruby 4.0 strict kwarg separation ([#156](https://github.com/mercadopago/sdk-ruby/pull/156))
### CI
- Standardize CI/CD workflows, migrate to mock-based unit tests, fix Ruby matrix ([#166](https://github.com/mercadopago/sdk-ruby/pull/166))

## Test plan
- [ ] CI passes
- [ ] Version string is correct in all files