### PR TITLE
chore: bump version to 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2026-08-27
+
+### Added
+- **Automatic payments**: support `automatic_payments.subscription` and expanded gateway network data.
+
+### CI
+- Publish to RubyGems through GitHub OIDC trusted publishing.
+
 ## [3.4.0] - 2026-08-11
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mercadopago-sdk (3.4.0)
+    mercadopago-sdk (3.5.0)
       faraday (~> 2.0)
       json (~> 2.5)
 

--- a/mercadopago.gemspec
+++ b/mercadopago.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name                  = 'mercadopago-sdk'
-  gem.version               = '3.4.0'
+  gem.version               = '3.5.0'
   gem.required_ruby_version = '>= 3.3.0'
   gem.author                = 'Mercado Pago'
   gem.description           = 'Mercado Pago Ruby SDK'


### PR DESCRIPTION
## Summary

Bumps the Ruby SDK release version to 3.5.0 after the latest merged backwards-compatible functionality.

## Files updated

- mercadopago.gemspec
- Gemfile.lock
- CHANGELOG.md

## Validation

- Confirmed version metadata and changelog consistency.
- No runtime code changes.